### PR TITLE
[WIP] AWS Broker v2

### DIFF
--- a/awsrds/aws_rds_suite_test.go
+++ b/awsrds/aws_rds_suite_test.go
@@ -1,0 +1,13 @@
+package awsrds_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAWSRDS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS RDS Suite")
+}

--- a/awsrds/db_cluster.go
+++ b/awsrds/db_cluster.go
@@ -1,0 +1,39 @@
+package awsrds
+
+import (
+	"errors"
+)
+
+type DBCluster interface {
+	Describe(ID string) (DBClusterDetails, error)
+	Create(ID string, dbClusterDetails DBClusterDetails) error
+	Modify(ID string, dbClusterDetails DBClusterDetails, applyImmediately bool) error
+	Delete(ID string, skipFinalSnapshot bool) error
+}
+
+type DBClusterDetails struct {
+	Identifier                  string
+	Status                      string
+	AllocatedStorage            int64
+	AvailabilityZones           []string
+	BackupRetentionPeriod       int64
+	CharacterSetName            string
+	DBClusterParameterGroupName string
+	DBSubnetGroupName           string
+	DatabaseName                string
+	Endpoint                    string
+	Engine                      string
+	EngineVersion               string
+	MasterUsername              string
+	MasterUserPassword          string
+	OptionGroupName             string
+	Port                        int64
+	PreferredBackupWindow       string
+	PreferredMaintenanceWindow  string
+	VpcSecurityGroupIds         []string
+	Tags                        map[string]string
+}
+
+var (
+	ErrDBClusterDoesNotExist = errors.New("rds db cluster does not exist")
+)

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -1,0 +1,52 @@
+package awsrds
+
+import (
+	"errors"
+)
+
+type DBInstance interface {
+	Describe(ID string) (DBInstanceDetails, error)
+	Create(ID string, dbInstanceDetails DBInstanceDetails) error
+	Modify(ID string, dbInstanceDetails DBInstanceDetails, applyImmediately bool) error
+	Delete(ID string, skipFinalSnapshot bool) error
+}
+
+type DBInstanceDetails struct {
+	Identifier                 string
+	Status                     string
+	DBInstanceClass            string
+	Engine                     string
+	EngineVersion              string
+	Address                    string
+	AllocatedStorage           int64
+	AutoMinorVersionUpgrade    bool
+	AvailabilityZone           string
+	BackupRetentionPeriod      int64
+	CharacterSetName           string
+	CopyTagsToSnapshot         bool
+	DBName                     string
+	DBClusterIdentifier        string
+	DBParameterGroupName       string
+	DBSecurityGroups           []string
+	DBSubnetGroupName          string
+	Iops                       int64
+	KmsKeyID                   string
+	LicenseModel               string
+	MasterUsername             string
+	MasterUserPassword         string
+	MultiAZ                    bool
+	OptionGroupName            string
+	PendingModifications       bool
+	Port                       int64
+	PreferredBackupWindow      string
+	PreferredMaintenanceWindow string
+	PubliclyAccessible         bool
+	StorageEncrypted           bool
+	StorageType                string
+	Tags                       map[string]string
+	VpcSecurityGroupIds        []string
+}
+
+var (
+	ErrDBInstanceDoesNotExist = errors.New("rds db instance does not exist")
+)

--- a/awsrds/fakes/fake_db_cluster.go
+++ b/awsrds/fakes/fake_db_cluster.go
@@ -1,0 +1,60 @@
+package fakes
+
+import (
+	"github.com/cf-platform-eng/sqs-broker/awsrds"
+)
+
+type FakeDBCluster struct {
+	DescribeCalled           bool
+	DescribeID               string
+	DescribeDBClusterDetails awsrds.DBClusterDetails
+	DescribeError            error
+
+	CreateCalled           bool
+	CreateID               string
+	CreateDBClusterDetails awsrds.DBClusterDetails
+	CreateError            error
+
+	ModifyCalled           bool
+	ModifyID               string
+	ModifyDBClusterDetails awsrds.DBClusterDetails
+	ModifyApplyImmediately bool
+	ModifyError            error
+
+	DeleteCalled            bool
+	DeleteID                string
+	DeleteSkipFinalSnapshot bool
+	DeleteError             error
+}
+
+func (f *FakeDBCluster) Describe(ID string) (awsrds.DBClusterDetails, error) {
+	f.DescribeCalled = true
+	f.DescribeID = ID
+
+	return f.DescribeDBClusterDetails, f.DescribeError
+}
+
+func (f *FakeDBCluster) Create(ID string, dbClusterDetails awsrds.DBClusterDetails) error {
+	f.CreateCalled = true
+	f.CreateID = ID
+	f.CreateDBClusterDetails = dbClusterDetails
+
+	return f.CreateError
+}
+
+func (f *FakeDBCluster) Modify(ID string, dbClusterDetails awsrds.DBClusterDetails, applyImmediately bool) error {
+	f.ModifyCalled = true
+	f.ModifyID = ID
+	f.ModifyDBClusterDetails = dbClusterDetails
+	f.ModifyApplyImmediately = applyImmediately
+
+	return f.ModifyError
+}
+
+func (f *FakeDBCluster) Delete(ID string, skipFinalSnapshot bool) error {
+	f.DeleteCalled = true
+	f.DeleteID = ID
+	f.DeleteSkipFinalSnapshot = skipFinalSnapshot
+
+	return f.DeleteError
+}

--- a/awsrds/fakes/fake_db_instance.go
+++ b/awsrds/fakes/fake_db_instance.go
@@ -1,0 +1,60 @@
+package fakes
+
+import (
+	"github.com/cf-platform-eng/sqs-broker/awsrds"
+)
+
+type FakeDBInstance struct {
+	DescribeCalled            bool
+	DescribeID                string
+	DescribeDBInstanceDetails awsrds.DBInstanceDetails
+	DescribeError             error
+
+	CreateCalled            bool
+	CreateID                string
+	CreateDBInstanceDetails awsrds.DBInstanceDetails
+	CreateError             error
+
+	ModifyCalled            bool
+	ModifyID                string
+	ModifyDBInstanceDetails awsrds.DBInstanceDetails
+	ModifyApplyImmediately  bool
+	ModifyError             error
+
+	DeleteCalled            bool
+	DeleteID                string
+	DeleteSkipFinalSnapshot bool
+	DeleteError             error
+}
+
+func (f *FakeDBInstance) Describe(ID string) (awsrds.DBInstanceDetails, error) {
+	f.DescribeCalled = true
+	f.DescribeID = ID
+
+	return f.DescribeDBInstanceDetails, f.DescribeError
+}
+
+func (f *FakeDBInstance) Create(ID string, dbInstanceDetails awsrds.DBInstanceDetails) error {
+	f.CreateCalled = true
+	f.CreateID = ID
+	f.CreateDBInstanceDetails = dbInstanceDetails
+
+	return f.CreateError
+}
+
+func (f *FakeDBInstance) Modify(ID string, dbInstanceDetails awsrds.DBInstanceDetails, applyImmediately bool) error {
+	f.ModifyCalled = true
+	f.ModifyID = ID
+	f.ModifyDBInstanceDetails = dbInstanceDetails
+	f.ModifyApplyImmediately = applyImmediately
+
+	return f.ModifyError
+}
+
+func (f *FakeDBInstance) Delete(ID string, skipFinalSnapshot bool) error {
+	f.DeleteCalled = true
+	f.DeleteID = ID
+	f.DeleteSkipFinalSnapshot = skipFinalSnapshot
+
+	return f.DeleteError
+}

--- a/awsrds/rds_db_cluster.go
+++ b/awsrds/rds_db_cluster.go
@@ -1,0 +1,291 @@
+package awsrds
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pivotal-golang/lager"
+)
+
+type RDSDBCluster struct {
+	region string
+	iamsvc *iam.IAM
+	rdssvc *rds.RDS
+	logger lager.Logger
+}
+
+func NewRDSDBCluster(
+	region string,
+	iamsvc *iam.IAM,
+	rdssvc *rds.RDS,
+	logger lager.Logger,
+) *RDSDBCluster {
+	return &RDSDBCluster{
+		region: region,
+		iamsvc: iamsvc,
+		rdssvc: rdssvc,
+		logger: logger.Session("db-cluster"),
+	}
+}
+
+func (r *RDSDBCluster) Describe(ID string) (DBClusterDetails, error) {
+	dbClusterDetails := DBClusterDetails{}
+
+	describeDBClustersInput := &rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(ID),
+	}
+
+	r.logger.Debug("describe-db-clusters", lager.Data{"input": describeDBClustersInput})
+
+	dbClusters, err := r.rdssvc.DescribeDBClusters(describeDBClustersInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return dbClusterDetails, ErrDBClusterDoesNotExist
+				}
+			}
+			return dbClusterDetails, errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return dbClusterDetails, err
+	}
+
+	for _, dbCluster := range dbClusters.DBClusters {
+		if aws.StringValue(dbCluster.DBClusterIdentifier) == ID {
+			r.logger.Debug("describe-db-clusters", lager.Data{"db-cluster": dbCluster})
+			return r.buildDBCluster(dbCluster), nil
+		}
+	}
+
+	return dbClusterDetails, ErrDBClusterDoesNotExist
+}
+
+func (r *RDSDBCluster) Create(ID string, dbClusterDetails DBClusterDetails) error {
+	createDBClusterInput := r.buildCreateDBClusterInput(ID, dbClusterDetails)
+	r.logger.Debug("create-db-cluster", lager.Data{"input": createDBClusterInput})
+
+	createDBClusterOutput, err := r.rdssvc.CreateDBCluster(createDBClusterInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return err
+	}
+	r.logger.Debug("create-db-cluster", lager.Data{"output": createDBClusterOutput})
+
+	return nil
+}
+
+func (r *RDSDBCluster) Modify(ID string, dbClusterDetails DBClusterDetails, applyImmediately bool) error {
+	modifyDBClusterInput := r.buildModifyDBClusterInput(ID, dbClusterDetails, applyImmediately)
+	r.logger.Debug("modify-db-cluster", lager.Data{"input": modifyDBClusterInput})
+
+	modifyDBClusterOutput, err := r.rdssvc.ModifyDBCluster(modifyDBClusterInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return ErrDBClusterDoesNotExist
+				}
+			}
+			return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return err
+	}
+
+	r.logger.Debug("modify-db-cluster", lager.Data{"output": modifyDBClusterOutput})
+
+	if len(dbClusterDetails.Tags) > 0 {
+		dbClusterARN, err := r.dbClusterARN(ID)
+		if err != nil {
+			return nil
+		}
+
+		tags := BuilRDSTags(dbClusterDetails.Tags)
+		AddTagsToResource(dbClusterARN, tags, r.rdssvc, r.logger)
+	}
+
+	return nil
+}
+
+func (r *RDSDBCluster) Delete(ID string, skipFinalSnapshot bool) error {
+	deleteDBClusterInput := r.buildDeleteDBClusterInput(ID, skipFinalSnapshot)
+	r.logger.Debug("delete-db-cluster", lager.Data{"input": deleteDBClusterInput})
+
+	deleteDBClusterOutput, err := r.rdssvc.DeleteDBCluster(deleteDBClusterInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return ErrDBClusterDoesNotExist
+				}
+			}
+			return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return err
+	}
+
+	r.logger.Debug("delete-db-cluster", lager.Data{"output": deleteDBClusterOutput})
+
+	return nil
+}
+func (r *RDSDBCluster) buildDBCluster(dbCluster *rds.DBCluster) DBClusterDetails {
+	dbClusterDetails := DBClusterDetails{
+		Identifier:       aws.StringValue(dbCluster.DBClusterIdentifier),
+		Status:           aws.StringValue(dbCluster.Status),
+		Engine:           aws.StringValue(dbCluster.Engine),
+		EngineVersion:    aws.StringValue(dbCluster.EngineVersion),
+		DatabaseName:     aws.StringValue(dbCluster.DatabaseName),
+		MasterUsername:   aws.StringValue(dbCluster.MasterUsername),
+		AllocatedStorage: aws.Int64Value(dbCluster.AllocatedStorage),
+		Endpoint:         aws.StringValue(dbCluster.Endpoint),
+		Port:             aws.Int64Value(dbCluster.Port),
+	}
+
+	return dbClusterDetails
+}
+
+func (r *RDSDBCluster) buildCreateDBClusterInput(ID string, dbClusterDetails DBClusterDetails) *rds.CreateDBClusterInput {
+	createDBClusterInput := &rds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String(ID),
+		Engine:              aws.String(dbClusterDetails.Engine),
+	}
+
+	if len(dbClusterDetails.AvailabilityZones) > 0 {
+		createDBClusterInput.AvailabilityZones = aws.StringSlice(dbClusterDetails.AvailabilityZones)
+	}
+
+	if dbClusterDetails.BackupRetentionPeriod > 0 {
+		createDBClusterInput.BackupRetentionPeriod = aws.Int64(dbClusterDetails.BackupRetentionPeriod)
+	}
+
+	if dbClusterDetails.CharacterSetName != "" {
+		createDBClusterInput.CharacterSetName = aws.String(dbClusterDetails.CharacterSetName)
+	}
+
+	if dbClusterDetails.DatabaseName != "" {
+		createDBClusterInput.DatabaseName = aws.String(dbClusterDetails.DatabaseName)
+	}
+
+	if dbClusterDetails.DBClusterParameterGroupName != "" {
+		createDBClusterInput.DBClusterParameterGroupName = aws.String(dbClusterDetails.DBClusterParameterGroupName)
+	}
+
+	if dbClusterDetails.DBSubnetGroupName != "" {
+		createDBClusterInput.DBSubnetGroupName = aws.String(dbClusterDetails.DBSubnetGroupName)
+	}
+
+	if dbClusterDetails.EngineVersion != "" {
+		createDBClusterInput.EngineVersion = aws.String(dbClusterDetails.EngineVersion)
+	}
+
+	if dbClusterDetails.MasterUsername != "" {
+		createDBClusterInput.MasterUsername = aws.String(dbClusterDetails.MasterUsername)
+	}
+
+	if dbClusterDetails.MasterUserPassword != "" {
+		createDBClusterInput.MasterUserPassword = aws.String(dbClusterDetails.MasterUserPassword)
+	}
+
+	if dbClusterDetails.OptionGroupName != "" {
+		createDBClusterInput.OptionGroupName = aws.String(dbClusterDetails.OptionGroupName)
+	}
+
+	if dbClusterDetails.Port > 0 {
+		createDBClusterInput.Port = aws.Int64(dbClusterDetails.Port)
+	}
+
+	if dbClusterDetails.PreferredBackupWindow != "" {
+		createDBClusterInput.PreferredBackupWindow = aws.String(dbClusterDetails.PreferredBackupWindow)
+	}
+
+	if dbClusterDetails.PreferredMaintenanceWindow != "" {
+		createDBClusterInput.PreferredMaintenanceWindow = aws.String(dbClusterDetails.PreferredMaintenanceWindow)
+	}
+
+	if len(dbClusterDetails.VpcSecurityGroupIds) > 0 {
+		createDBClusterInput.VpcSecurityGroupIds = aws.StringSlice(dbClusterDetails.VpcSecurityGroupIds)
+	}
+
+	if len(dbClusterDetails.Tags) > 0 {
+		createDBClusterInput.Tags = BuilRDSTags(dbClusterDetails.Tags)
+	}
+
+	return createDBClusterInput
+}
+
+func (r *RDSDBCluster) buildModifyDBClusterInput(ID string, dbClusterDetails DBClusterDetails, applyImmediately bool) *rds.ModifyDBClusterInput {
+	modifyDBClusterInput := &rds.ModifyDBClusterInput{
+		DBClusterIdentifier: aws.String(ID),
+		ApplyImmediately:    aws.Bool(applyImmediately),
+	}
+
+	if dbClusterDetails.BackupRetentionPeriod > 0 {
+		modifyDBClusterInput.BackupRetentionPeriod = aws.Int64(dbClusterDetails.BackupRetentionPeriod)
+	}
+
+	if dbClusterDetails.DBClusterParameterGroupName != "" {
+		modifyDBClusterInput.DBClusterParameterGroupName = aws.String(dbClusterDetails.DBClusterParameterGroupName)
+	}
+
+	if dbClusterDetails.MasterUserPassword != "" {
+		modifyDBClusterInput.MasterUserPassword = aws.String(dbClusterDetails.MasterUserPassword)
+	}
+
+	if dbClusterDetails.OptionGroupName != "" {
+		modifyDBClusterInput.OptionGroupName = aws.String(dbClusterDetails.OptionGroupName)
+	}
+
+	if dbClusterDetails.Port > 0 {
+		modifyDBClusterInput.Port = aws.Int64(dbClusterDetails.Port)
+	}
+
+	if dbClusterDetails.PreferredBackupWindow != "" {
+		modifyDBClusterInput.PreferredBackupWindow = aws.String(dbClusterDetails.PreferredBackupWindow)
+	}
+
+	if dbClusterDetails.PreferredMaintenanceWindow != "" {
+		modifyDBClusterInput.PreferredMaintenanceWindow = aws.String(dbClusterDetails.PreferredMaintenanceWindow)
+	}
+
+	if len(dbClusterDetails.VpcSecurityGroupIds) > 0 {
+		modifyDBClusterInput.VpcSecurityGroupIds = aws.StringSlice(dbClusterDetails.VpcSecurityGroupIds)
+	}
+
+	return modifyDBClusterInput
+}
+
+func (r *RDSDBCluster) buildDeleteDBClusterInput(ID string, skipFinalSnapshot bool) *rds.DeleteDBClusterInput {
+	deleteDBClusterInput := &rds.DeleteDBClusterInput{
+		DBClusterIdentifier: aws.String(ID),
+		SkipFinalSnapshot:   aws.Bool(skipFinalSnapshot),
+	}
+
+	if !skipFinalSnapshot {
+		deleteDBClusterInput.FinalDBSnapshotIdentifier = aws.String(r.dbSnapshotName(ID))
+	}
+
+	return deleteDBClusterInput
+}
+
+func (r *RDSDBCluster) dbSnapshotName(ID string) string {
+	return fmt.Sprintf("rds-broker-%s-%s", ID, time.Now().Format("2006-01-02-15-04-05"))
+}
+
+func (r *RDSDBCluster) dbClusterARN(ID string) (string, error) {
+	userAccount, err := UserAccount(r.iamsvc)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("arn:aws:rds:%s:%s:db:%s", r.region, userAccount, ID), nil
+}

--- a/awsrds/rds_db_cluster_test.go
+++ b/awsrds/rds_db_cluster_test.go
@@ -1,0 +1,769 @@
+package awsrds_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/awsrds"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pivotal-golang/lager"
+	"github.com/pivotal-golang/lager/lagertest"
+)
+
+var _ = Describe("RDS DB Cluster", func() {
+	var (
+		region              string
+		dbClusterIdentifier string
+
+		awsSession *session.Session
+
+		iamsvc  *iam.IAM
+		iamCall func(r *request.Request)
+
+		rdssvc  *rds.RDS
+		rdsCall func(r *request.Request)
+
+		testSink *lagertest.TestSink
+		logger   lager.Logger
+
+		rdsDBCluster DBCluster
+	)
+
+	BeforeEach(func() {
+		region = "rds-region"
+		dbClusterIdentifier = "cf-cluster-id"
+	})
+
+	JustBeforeEach(func() {
+		awsSession = session.New(nil)
+
+		iamsvc = iam.New(awsSession)
+		rdssvc = rds.New(awsSession)
+
+		logger = lager.NewLogger("rdsdbcluster_test")
+		testSink = lagertest.NewTestSink()
+		logger.RegisterSink(testSink)
+
+		rdsDBCluster = NewRDSDBCluster(region, iamsvc, rdssvc, logger)
+	})
+
+	var _ = Describe("Describe", func() {
+		var (
+			properDBClusterDetails DBClusterDetails
+
+			describeDBClusters []*rds.DBCluster
+			describeDBCluster  *rds.DBCluster
+
+			describeDBClustersInput *rds.DescribeDBClustersInput
+			describeDBClusterError  error
+		)
+
+		BeforeEach(func() {
+			properDBClusterDetails = DBClusterDetails{
+				Identifier:       dbClusterIdentifier,
+				Status:           "available",
+				Engine:           "test-engine",
+				EngineVersion:    "1.2.3",
+				DatabaseName:     "test-dbname",
+				MasterUsername:   "test-master-username",
+				AllocatedStorage: int64(100),
+				Endpoint:         "test-endpoint",
+				Port:             int64(3306),
+			}
+
+			describeDBCluster = &rds.DBCluster{
+				DBClusterIdentifier: aws.String(dbClusterIdentifier),
+				Status:              aws.String("available"),
+				Engine:              aws.String("test-engine"),
+				EngineVersion:       aws.String("1.2.3"),
+				DatabaseName:        aws.String("test-dbname"),
+				MasterUsername:      aws.String("test-master-username"),
+				AllocatedStorage:    aws.Int64(100),
+				Endpoint:            aws.String("test-endpoint"),
+				Port:                aws.Int64(3306),
+			}
+			describeDBClusters = []*rds.DBCluster{describeDBCluster}
+
+			describeDBClustersInput = &rds.DescribeDBClustersInput{
+				DBClusterIdentifier: aws.String(dbClusterIdentifier),
+			}
+			describeDBClusterError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("DescribeDBClusters"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&rds.DescribeDBClustersInput{}))
+				Expect(r.Params).To(Equal(describeDBClustersInput))
+				data := r.Data.(*rds.DescribeDBClustersOutput)
+				data.DBClusters = describeDBClusters
+				r.Error = describeDBClusterError
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+		})
+
+		It("returns the proper DB Cluster", func() {
+			dbClusterDetails, err := rdsDBCluster.Describe(dbClusterIdentifier)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dbClusterDetails).To(Equal(properDBClusterDetails))
+		})
+
+		Context("when the DB Cluster does not exists", func() {
+			JustBeforeEach(func() {
+				describeDBClustersInput = &rds.DescribeDBClustersInput{
+					DBClusterIdentifier: aws.String("unknown"),
+				}
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsDBCluster.Describe("unknown")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(ErrDBClusterDoesNotExist))
+			})
+		})
+
+		Context("when describing the DB Cluster fails", func() {
+			BeforeEach(func() {
+				describeDBClusterError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsDBCluster.Describe(dbClusterIdentifier)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					describeDBClusterError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsDBCluster.Describe(dbClusterIdentifier)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+
+			Context("and it is a 404 error", func() {
+				BeforeEach(func() {
+					awsError := awserr.New("code", "message", errors.New("operation failed"))
+					describeDBClusterError = awserr.NewRequestFailure(awsError, 404, "request-id")
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsDBCluster.Describe(dbClusterIdentifier)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(ErrDBClusterDoesNotExist))
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Create", func() {
+		var (
+			dbClusterDetails DBClusterDetails
+
+			createDBClustersInput *rds.CreateDBClusterInput
+			createDBClusterError  error
+		)
+
+		BeforeEach(func() {
+			dbClusterDetails = DBClusterDetails{
+				Engine: "test-engine",
+			}
+
+			createDBClustersInput = &rds.CreateDBClusterInput{
+				DBClusterIdentifier: aws.String(dbClusterIdentifier),
+				Engine:              aws.String("test-engine"),
+			}
+			createDBClusterError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("CreateDBCluster"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&rds.CreateDBClusterInput{}))
+				Expect(r.Params).To(Equal(createDBClustersInput))
+				r.Error = createDBClusterError
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+		})
+
+		It("does not return error", func() {
+			err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when has AvailabilityZones", func() {
+			BeforeEach(func() {
+				dbClusterDetails.AvailabilityZones = []string{"test-az"}
+				createDBClustersInput.AvailabilityZones = aws.StringSlice([]string{"test-az"})
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has BackupRetentionPeriod", func() {
+			BeforeEach(func() {
+				dbClusterDetails.BackupRetentionPeriod = 7
+				createDBClustersInput.BackupRetentionPeriod = aws.Int64(7)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has CharacterSetName", func() {
+			BeforeEach(func() {
+				dbClusterDetails.CharacterSetName = "test-characterset-name"
+				createDBClustersInput.CharacterSetName = aws.String("test-characterset-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DatabaseName", func() {
+			BeforeEach(func() {
+				dbClusterDetails.DatabaseName = "test-database-name"
+				createDBClustersInput.DatabaseName = aws.String("test-database-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBClusterParameterGroupName", func() {
+			BeforeEach(func() {
+				dbClusterDetails.DBClusterParameterGroupName = "test-db-cluster-parameter-group-name"
+				createDBClustersInput.DBClusterParameterGroupName = aws.String("test-db-cluster-parameter-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBSubnetGroupName", func() {
+			BeforeEach(func() {
+				dbClusterDetails.DBSubnetGroupName = "test-db-subnet-group-name"
+				createDBClustersInput.DBSubnetGroupName = aws.String("test-db-subnet-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has EngineVersion", func() {
+			BeforeEach(func() {
+				dbClusterDetails.EngineVersion = "1.2.3"
+				createDBClustersInput.EngineVersion = aws.String("1.2.3")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has MasterUsername", func() {
+			BeforeEach(func() {
+				dbClusterDetails.MasterUsername = "test-master-username"
+				createDBClustersInput.MasterUsername = aws.String("test-master-username")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has MasterUserPassword", func() {
+			BeforeEach(func() {
+				dbClusterDetails.MasterUserPassword = "test-master-user-password"
+				createDBClustersInput.MasterUserPassword = aws.String("test-master-user-password")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has OptionGroupName", func() {
+			BeforeEach(func() {
+				dbClusterDetails.OptionGroupName = "test-option-group-name"
+				createDBClustersInput.OptionGroupName = aws.String("test-option-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Port", func() {
+			BeforeEach(func() {
+				dbClusterDetails.Port = 666
+				createDBClustersInput.Port = aws.Int64(666)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredBackupWindow", func() {
+			BeforeEach(func() {
+				dbClusterDetails.PreferredBackupWindow = "test-preferred-backup-window"
+				createDBClustersInput.PreferredBackupWindow = aws.String("test-preferred-backup-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredMaintenanceWindow", func() {
+			BeforeEach(func() {
+				dbClusterDetails.PreferredMaintenanceWindow = "test-preferred-maintenance-window"
+				createDBClustersInput.PreferredMaintenanceWindow = aws.String("test-preferred-maintenance-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has VpcSecurityGroupIds", func() {
+			BeforeEach(func() {
+				dbClusterDetails.VpcSecurityGroupIds = []string{"test-vpc-security-group-ids"}
+				createDBClustersInput.VpcSecurityGroupIds = aws.StringSlice([]string{"test-vpc-security-group-ids"})
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Tags", func() {
+			BeforeEach(func() {
+				dbClusterDetails.Tags = map[string]string{"Owner": "Cloud Foundry"}
+				createDBClustersInput.Tags = []*rds.Tag{
+					&rds.Tag{Key: aws.String("Owner"), Value: aws.String("Cloud Foundry")},
+				}
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when creating the DB Cluster fails", func() {
+			BeforeEach(func() {
+				createDBClusterError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					createDBClusterError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBCluster.Create(dbClusterIdentifier, dbClusterDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Modify", func() {
+		var (
+			dbClusterDetails DBClusterDetails
+			applyImmediately bool
+
+			describeDBClustersInput *rds.DescribeDBClustersInput
+			describeDBClusterError  error
+
+			modifyDBClusterInput *rds.ModifyDBClusterInput
+			modifyDBClusterError error
+
+			addTagsToResourceInput *rds.AddTagsToResourceInput
+			addTagsToResourceError error
+
+			user         *iam.User
+			getUserInput *iam.GetUserInput
+			getUserError error
+		)
+
+		BeforeEach(func() {
+			dbClusterDetails = DBClusterDetails{}
+			applyImmediately = false
+
+			describeDBClustersInput = &rds.DescribeDBClustersInput{
+				DBClusterIdentifier: aws.String(dbClusterIdentifier),
+			}
+			describeDBClusterError = nil
+
+			modifyDBClusterInput = &rds.ModifyDBClusterInput{
+				DBClusterIdentifier: aws.String(dbClusterIdentifier),
+				ApplyImmediately:    aws.Bool(applyImmediately),
+			}
+			modifyDBClusterError = nil
+
+			addTagsToResourceInput = &rds.AddTagsToResourceInput{
+				ResourceName: aws.String("arn:aws:rds:rds-region:account:db:" + dbClusterIdentifier),
+				Tags: []*rds.Tag{
+					&rds.Tag{
+						Key:   aws.String("Owner"),
+						Value: aws.String("Cloud Foundry"),
+					},
+				},
+			}
+			addTagsToResourceError = nil
+
+			user = &iam.User{
+				Arn: aws.String("arn:aws:service:region:account:resource"),
+			}
+			getUserInput = &iam.GetUserInput{}
+			getUserError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(MatchRegexp("ModifyDBCluster|AddTagsToResource"))
+				switch r.Operation.Name {
+				case "ModifyDBCluster":
+					Expect(r.Params).To(BeAssignableToTypeOf(&rds.ModifyDBClusterInput{}))
+					Expect(r.Params).To(Equal(modifyDBClusterInput))
+					r.Error = modifyDBClusterError
+				case "AddTagsToResource":
+					Expect(r.Params).To(BeAssignableToTypeOf(&rds.AddTagsToResourceInput{}))
+					Expect(r.Params).To(Equal(addTagsToResourceInput))
+					r.Error = addTagsToResourceError
+				}
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+
+			iamsvc.Handlers.Clear()
+			iamCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("GetUser"))
+				Expect(r.Params).To(Equal(getUserInput))
+				data := r.Data.(*iam.GetUserOutput)
+				data.User = user
+				r.Error = getUserError
+			}
+			iamsvc.Handlers.Send.PushBack(iamCall)
+		})
+
+		It("does not return error", func() {
+			err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when apply immediately is set to true", func() {
+			BeforeEach(func() {
+				applyImmediately = true
+				modifyDBClusterInput.ApplyImmediately = aws.Bool(true)
+			})
+
+			It("returns the proper DB Cluster", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has BackupRetentionPeriod", func() {
+			BeforeEach(func() {
+				dbClusterDetails.BackupRetentionPeriod = 7
+				modifyDBClusterInput.BackupRetentionPeriod = aws.Int64(7)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBClusterParameterGroupName", func() {
+			BeforeEach(func() {
+				dbClusterDetails.DBClusterParameterGroupName = "test-db-cluster-parameter-group-name"
+				modifyDBClusterInput.DBClusterParameterGroupName = aws.String("test-db-cluster-parameter-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has MasterUserPassword", func() {
+			BeforeEach(func() {
+				dbClusterDetails.MasterUserPassword = "test-master-user-password"
+				modifyDBClusterInput.MasterUserPassword = aws.String("test-master-user-password")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has OptionGroupName", func() {
+			BeforeEach(func() {
+				dbClusterDetails.OptionGroupName = "test-option-group-name"
+				modifyDBClusterInput.OptionGroupName = aws.String("test-option-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Port", func() {
+			BeforeEach(func() {
+				dbClusterDetails.Port = 666
+				modifyDBClusterInput.Port = aws.Int64(666)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredBackupWindow", func() {
+			BeforeEach(func() {
+				dbClusterDetails.PreferredBackupWindow = "test-preferred-backup-window"
+				modifyDBClusterInput.PreferredBackupWindow = aws.String("test-preferred-backup-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredMaintenanceWindow", func() {
+			BeforeEach(func() {
+				dbClusterDetails.PreferredMaintenanceWindow = "test-preferred-maintenance-window"
+				modifyDBClusterInput.PreferredMaintenanceWindow = aws.String("test-preferred-maintenance-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has VpcSecurityGroupIds", func() {
+			BeforeEach(func() {
+				dbClusterDetails.VpcSecurityGroupIds = []string{"test-vpc-security-group-ids"}
+				modifyDBClusterInput.VpcSecurityGroupIds = aws.StringSlice([]string{"test-vpc-security-group-ids"})
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Tags", func() {
+			BeforeEach(func() {
+				dbClusterDetails.Tags = map[string]string{"Owner": "Cloud Foundry"}
+			})
+
+			It("does not return error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when adding tags to resource fails", func() {
+				BeforeEach(func() {
+					addTagsToResourceError = errors.New("operation failed")
+				})
+
+				It("does not return error", func() {
+					err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when getting user arn fails", func() {
+				BeforeEach(func() {
+					getUserError = errors.New("operation failed")
+				})
+
+				It("does not return error", func() {
+					err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when modifying the DB cluster fails", func() {
+			BeforeEach(func() {
+				modifyDBClusterError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					modifyDBClusterError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+
+			Context("and it is a 404 error", func() {
+				BeforeEach(func() {
+					awsError := awserr.New("code", "message", errors.New("operation failed"))
+					modifyDBClusterError = awserr.NewRequestFailure(awsError, 404, "request-id")
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBCluster.Modify(dbClusterIdentifier, dbClusterDetails, applyImmediately)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(ErrDBClusterDoesNotExist))
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Delete", func() {
+		var (
+			skipFinalSnapshot         bool
+			finalDBSnapshotIdentifier string
+
+			deleteDBClusterError error
+		)
+
+		BeforeEach(func() {
+			skipFinalSnapshot = true
+			finalDBSnapshotIdentifier = ""
+			deleteDBClusterError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("DeleteDBCluster"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&rds.DeleteDBClusterInput{}))
+				params := r.Params.(*rds.DeleteDBClusterInput)
+				Expect(params.DBClusterIdentifier).To(Equal(aws.String(dbClusterIdentifier)))
+				if finalDBSnapshotIdentifier != "" {
+					Expect(*params.FinalDBSnapshotIdentifier).To(ContainSubstring(finalDBSnapshotIdentifier))
+				} else {
+					Expect(params.FinalDBSnapshotIdentifier).To(BeNil())
+				}
+				Expect(params.SkipFinalSnapshot).To(Equal(aws.Bool(skipFinalSnapshot)))
+				r.Error = deleteDBClusterError
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+		})
+
+		It("does not return error", func() {
+			err := rdsDBCluster.Delete(dbClusterIdentifier, skipFinalSnapshot)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when does not skip the final snapshot", func() {
+			BeforeEach(func() {
+				skipFinalSnapshot = false
+				finalDBSnapshotIdentifier = "rds-broker-" + dbClusterIdentifier
+			})
+
+			It("returns the proper DB Cluster", func() {
+				err := rdsDBCluster.Delete(dbClusterIdentifier, skipFinalSnapshot)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when deleting the DB Cluster fails", func() {
+			BeforeEach(func() {
+				deleteDBClusterError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBCluster.Delete(dbClusterIdentifier, skipFinalSnapshot)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					deleteDBClusterError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBCluster.Delete(dbClusterIdentifier, skipFinalSnapshot)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+
+			Context("and it is a 404 error", func() {
+				BeforeEach(func() {
+					awsError := awserr.New("code", "message", errors.New("operation failed"))
+					deleteDBClusterError = awserr.NewRequestFailure(awsError, 404, "request-id")
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBCluster.Delete(dbClusterIdentifier, skipFinalSnapshot)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(ErrDBClusterDoesNotExist))
+				})
+			})
+		})
+	})
+})

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -1,0 +1,404 @@
+package awsrds
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pivotal-golang/lager"
+)
+
+type RDSDBInstance struct {
+	region string
+	iamsvc *iam.IAM
+	rdssvc *rds.RDS
+	logger lager.Logger
+}
+
+func NewRDSDBInstance(
+	region string,
+	iamsvc *iam.IAM,
+	rdssvc *rds.RDS,
+	logger lager.Logger,
+) *RDSDBInstance {
+	return &RDSDBInstance{
+		region: region,
+		iamsvc: iamsvc,
+		rdssvc: rdssvc,
+		logger: logger.Session("db-instance"),
+	}
+}
+
+func (r *RDSDBInstance) Describe(ID string) (DBInstanceDetails, error) {
+	dbInstanceDetails := DBInstanceDetails{}
+
+	describeDBInstancesInput := &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(ID),
+	}
+
+	r.logger.Debug("describe-db-instances", lager.Data{"input": describeDBInstancesInput})
+
+	dbInstances, err := r.rdssvc.DescribeDBInstances(describeDBInstancesInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return dbInstanceDetails, ErrDBInstanceDoesNotExist
+				}
+			}
+			return dbInstanceDetails, errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return dbInstanceDetails, err
+	}
+
+	for _, dbInstance := range dbInstances.DBInstances {
+		if aws.StringValue(dbInstance.DBInstanceIdentifier) == ID {
+			r.logger.Debug("describe-db-instances", lager.Data{"db-instance": dbInstance})
+			return r.buildDBInstance(dbInstance), nil
+		}
+	}
+
+	return dbInstanceDetails, ErrDBInstanceDoesNotExist
+}
+
+func (r *RDSDBInstance) Create(ID string, dbInstanceDetails DBInstanceDetails) error {
+	createDBInstanceInput := r.buildCreateDBInstanceInput(ID, dbInstanceDetails)
+	r.logger.Debug("create-db-instance", lager.Data{"input": createDBInstanceInput})
+
+	createDBInstanceOutput, err := r.rdssvc.CreateDBInstance(createDBInstanceInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return ErrDBClusterDoesNotExist
+				}
+			}
+			return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return err
+	}
+	r.logger.Debug("create-db-instance", lager.Data{"output": createDBInstanceOutput})
+
+	return nil
+}
+
+func (r *RDSDBInstance) Modify(ID string, dbInstanceDetails DBInstanceDetails, applyImmediately bool) error {
+	oldDBInstanceDetails, err := r.Describe(ID)
+	if err != nil {
+		return err
+	}
+
+	if dbInstanceDetails.Engine != "" && strings.ToLower(oldDBInstanceDetails.Engine) != strings.ToLower(dbInstanceDetails.Engine) {
+		return fmt.Errorf("Migrating the RDS DB Instance engine from '%s' to '%s' is not supported", oldDBInstanceDetails.Engine, dbInstanceDetails.Engine)
+	}
+
+	modifyDBInstanceInput := r.buildModifyDBInstanceInput(ID, dbInstanceDetails, oldDBInstanceDetails, applyImmediately)
+	r.logger.Debug("modify-db-instance", lager.Data{"input": modifyDBInstanceInput})
+
+	modifyDBInstanceOutput, err := r.rdssvc.ModifyDBInstance(modifyDBInstanceInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return ErrDBClusterDoesNotExist
+				}
+			}
+			return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return err
+	}
+
+	r.logger.Debug("modify-db-instance", lager.Data{"output": modifyDBInstanceOutput})
+
+	if len(dbInstanceDetails.Tags) > 0 {
+		dbInstanceARN, err := r.dbInstanceARN(ID)
+		if err != nil {
+			return nil
+		}
+
+		tags := BuilRDSTags(dbInstanceDetails.Tags)
+		AddTagsToResource(dbInstanceARN, tags, r.rdssvc, r.logger)
+	}
+
+	return nil
+}
+
+func (r *RDSDBInstance) Delete(ID string, skipFinalSnapshot bool) error {
+	deleteDBInstanceInput := r.buildDeleteDBInstanceInput(ID, skipFinalSnapshot)
+	r.logger.Debug("delete-db-instance", lager.Data{"input": deleteDBInstanceInput})
+
+	deleteDBInstanceOutput, err := r.rdssvc.DeleteDBInstance(deleteDBInstanceInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return ErrDBInstanceDoesNotExist
+				}
+			}
+			return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return err
+	}
+
+	r.logger.Debug("delete-db-instance", lager.Data{"output": deleteDBInstanceOutput})
+
+	return nil
+}
+
+func (r *RDSDBInstance) buildDBInstance(dbInstance *rds.DBInstance) DBInstanceDetails {
+	dbInstanceDetails := DBInstanceDetails{
+		Identifier:       aws.StringValue(dbInstance.DBInstanceIdentifier),
+		Status:           aws.StringValue(dbInstance.DBInstanceStatus),
+		Engine:           aws.StringValue(dbInstance.Engine),
+		EngineVersion:    aws.StringValue(dbInstance.EngineVersion),
+		DBName:           aws.StringValue(dbInstance.DBName),
+		MasterUsername:   aws.StringValue(dbInstance.MasterUsername),
+		AllocatedStorage: aws.Int64Value(dbInstance.AllocatedStorage),
+	}
+
+	if dbInstance.Endpoint != nil {
+		dbInstanceDetails.Address = aws.StringValue(dbInstance.Endpoint.Address)
+		dbInstanceDetails.Port = aws.Int64Value(dbInstance.Endpoint.Port)
+	}
+
+	if dbInstance.PendingModifiedValues != nil {
+		emptyPendingModifiedValues := &rds.PendingModifiedValues{}
+		if *dbInstance.PendingModifiedValues != *emptyPendingModifiedValues {
+			dbInstanceDetails.PendingModifications = true
+		}
+	}
+
+	return dbInstanceDetails
+}
+
+func (r *RDSDBInstance) buildCreateDBInstanceInput(ID string, dbInstanceDetails DBInstanceDetails) *rds.CreateDBInstanceInput {
+	createDBInstanceInput := &rds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String(ID),
+		Engine:               aws.String(dbInstanceDetails.Engine),
+	}
+
+	if dbInstanceDetails.AllocatedStorage > 0 {
+		createDBInstanceInput.AllocatedStorage = aws.Int64(dbInstanceDetails.AllocatedStorage)
+	}
+
+	createDBInstanceInput.AutoMinorVersionUpgrade = aws.Bool(dbInstanceDetails.AutoMinorVersionUpgrade)
+
+	if dbInstanceDetails.AvailabilityZone != "" {
+		createDBInstanceInput.AvailabilityZone = aws.String(dbInstanceDetails.AvailabilityZone)
+	}
+
+	if dbInstanceDetails.BackupRetentionPeriod > 0 {
+		createDBInstanceInput.BackupRetentionPeriod = aws.Int64(dbInstanceDetails.BackupRetentionPeriod)
+	}
+
+	if dbInstanceDetails.CharacterSetName != "" {
+		createDBInstanceInput.CharacterSetName = aws.String(dbInstanceDetails.CharacterSetName)
+	}
+
+	createDBInstanceInput.CopyTagsToSnapshot = aws.Bool(dbInstanceDetails.CopyTagsToSnapshot)
+
+	if dbInstanceDetails.DBClusterIdentifier != "" {
+		createDBInstanceInput.DBClusterIdentifier = aws.String(dbInstanceDetails.DBClusterIdentifier)
+	}
+
+	if dbInstanceDetails.DBInstanceClass != "" {
+		createDBInstanceInput.DBInstanceClass = aws.String(dbInstanceDetails.DBInstanceClass)
+	}
+
+	if dbInstanceDetails.DBName != "" {
+		createDBInstanceInput.DBName = aws.String(dbInstanceDetails.DBName)
+	}
+
+	if dbInstanceDetails.DBParameterGroupName != "" {
+		createDBInstanceInput.DBParameterGroupName = aws.String(dbInstanceDetails.DBParameterGroupName)
+	}
+
+	if len(dbInstanceDetails.DBSecurityGroups) > 0 {
+		createDBInstanceInput.DBSecurityGroups = aws.StringSlice(dbInstanceDetails.DBSecurityGroups)
+	}
+
+	if dbInstanceDetails.DBSubnetGroupName != "" {
+		createDBInstanceInput.DBSubnetGroupName = aws.String(dbInstanceDetails.DBSubnetGroupName)
+	}
+
+	if dbInstanceDetails.EngineVersion != "" {
+		createDBInstanceInput.EngineVersion = aws.String(dbInstanceDetails.EngineVersion)
+	}
+
+	if dbInstanceDetails.KmsKeyID != "" {
+		createDBInstanceInput.KmsKeyId = aws.String(dbInstanceDetails.KmsKeyID)
+	}
+
+	if dbInstanceDetails.LicenseModel != "" {
+		createDBInstanceInput.LicenseModel = aws.String(dbInstanceDetails.LicenseModel)
+	}
+
+	if dbInstanceDetails.MasterUsername != "" {
+		createDBInstanceInput.MasterUsername = aws.String(dbInstanceDetails.MasterUsername)
+	}
+
+	if dbInstanceDetails.MasterUserPassword != "" {
+		createDBInstanceInput.MasterUserPassword = aws.String(dbInstanceDetails.MasterUserPassword)
+	}
+
+	createDBInstanceInput.MultiAZ = aws.Bool(dbInstanceDetails.MultiAZ)
+
+	if dbInstanceDetails.OptionGroupName != "" {
+		createDBInstanceInput.OptionGroupName = aws.String(dbInstanceDetails.OptionGroupName)
+	}
+
+	if dbInstanceDetails.Port > 0 {
+		createDBInstanceInput.Port = aws.Int64(dbInstanceDetails.Port)
+	}
+
+	if dbInstanceDetails.PreferredBackupWindow != "" {
+		createDBInstanceInput.PreferredBackupWindow = aws.String(dbInstanceDetails.PreferredBackupWindow)
+	}
+
+	if dbInstanceDetails.PreferredMaintenanceWindow != "" {
+		createDBInstanceInput.PreferredMaintenanceWindow = aws.String(dbInstanceDetails.PreferredMaintenanceWindow)
+	}
+
+	createDBInstanceInput.PubliclyAccessible = aws.Bool(dbInstanceDetails.PubliclyAccessible)
+
+	createDBInstanceInput.StorageEncrypted = aws.Bool(dbInstanceDetails.StorageEncrypted)
+
+	if dbInstanceDetails.StorageType != "" {
+		createDBInstanceInput.StorageType = aws.String(dbInstanceDetails.StorageType)
+	}
+
+	if dbInstanceDetails.Iops > 0 {
+		createDBInstanceInput.Iops = aws.Int64(dbInstanceDetails.Iops)
+	}
+
+	if len(dbInstanceDetails.VpcSecurityGroupIds) > 0 {
+		createDBInstanceInput.VpcSecurityGroupIds = aws.StringSlice(dbInstanceDetails.VpcSecurityGroupIds)
+	}
+
+	if len(dbInstanceDetails.Tags) > 0 {
+		createDBInstanceInput.Tags = BuilRDSTags(dbInstanceDetails.Tags)
+	}
+
+	return createDBInstanceInput
+}
+
+func (r *RDSDBInstance) buildModifyDBInstanceInput(ID string, dbInstanceDetails DBInstanceDetails, oldDBInstanceDetails DBInstanceDetails, applyImmediately bool) *rds.ModifyDBInstanceInput {
+	modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String(ID),
+		ApplyImmediately:     aws.Bool(applyImmediately),
+	}
+
+	if dbInstanceDetails.AllocatedStorage > 0 {
+		if dbInstanceDetails.AllocatedStorage < oldDBInstanceDetails.AllocatedStorage {
+			modifyDBInstanceInput.AllocatedStorage = aws.Int64(oldDBInstanceDetails.AllocatedStorage)
+		} else {
+			modifyDBInstanceInput.AllocatedStorage = aws.Int64(dbInstanceDetails.AllocatedStorage)
+		}
+	}
+
+	modifyDBInstanceInput.AutoMinorVersionUpgrade = aws.Bool(dbInstanceDetails.AutoMinorVersionUpgrade)
+
+	if dbInstanceDetails.BackupRetentionPeriod > 0 {
+		modifyDBInstanceInput.BackupRetentionPeriod = aws.Int64(dbInstanceDetails.BackupRetentionPeriod)
+	}
+
+	modifyDBInstanceInput.CopyTagsToSnapshot = aws.Bool(dbInstanceDetails.CopyTagsToSnapshot)
+
+	if dbInstanceDetails.DBInstanceClass != "" {
+		modifyDBInstanceInput.DBInstanceClass = aws.String(dbInstanceDetails.DBInstanceClass)
+	}
+
+	if dbInstanceDetails.DBParameterGroupName != "" {
+		modifyDBInstanceInput.DBParameterGroupName = aws.String(dbInstanceDetails.DBParameterGroupName)
+	}
+
+	if len(dbInstanceDetails.DBSecurityGroups) > 0 {
+		modifyDBInstanceInput.DBSecurityGroups = aws.StringSlice(dbInstanceDetails.DBSecurityGroups)
+	}
+
+	if dbInstanceDetails.EngineVersion != "" && dbInstanceDetails.EngineVersion != oldDBInstanceDetails.EngineVersion {
+		modifyDBInstanceInput.EngineVersion = aws.String(dbInstanceDetails.EngineVersion)
+		modifyDBInstanceInput.AllowMajorVersionUpgrade = aws.Bool(r.allowMajorVersionUpgrade(dbInstanceDetails.EngineVersion, oldDBInstanceDetails.EngineVersion))
+	}
+
+	if dbInstanceDetails.MasterUserPassword != "" {
+		modifyDBInstanceInput.MasterUserPassword = aws.String(dbInstanceDetails.MasterUserPassword)
+	}
+
+	modifyDBInstanceInput.MultiAZ = aws.Bool(dbInstanceDetails.MultiAZ)
+
+	if dbInstanceDetails.OptionGroupName != "" {
+		modifyDBInstanceInput.OptionGroupName = aws.String(dbInstanceDetails.OptionGroupName)
+	}
+
+	if dbInstanceDetails.PreferredBackupWindow != "" {
+		modifyDBInstanceInput.PreferredBackupWindow = aws.String(dbInstanceDetails.PreferredBackupWindow)
+	}
+
+	if dbInstanceDetails.PreferredMaintenanceWindow != "" {
+		modifyDBInstanceInput.PreferredMaintenanceWindow = aws.String(dbInstanceDetails.PreferredMaintenanceWindow)
+	}
+
+	if dbInstanceDetails.StorageType != "" {
+		modifyDBInstanceInput.StorageType = aws.String(dbInstanceDetails.StorageType)
+	}
+
+	if dbInstanceDetails.Iops > 0 {
+		modifyDBInstanceInput.Iops = aws.Int64(dbInstanceDetails.Iops)
+	}
+
+	if len(dbInstanceDetails.VpcSecurityGroupIds) > 0 {
+		modifyDBInstanceInput.VpcSecurityGroupIds = aws.StringSlice(dbInstanceDetails.VpcSecurityGroupIds)
+	}
+
+	return modifyDBInstanceInput
+}
+
+func (r *RDSDBInstance) buildDeleteDBInstanceInput(ID string, skipFinalSnapshot bool) *rds.DeleteDBInstanceInput {
+	deleteDBInstanceInput := &rds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String(ID),
+		SkipFinalSnapshot:    aws.Bool(skipFinalSnapshot),
+	}
+
+	if !skipFinalSnapshot {
+		deleteDBInstanceInput.FinalDBSnapshotIdentifier = aws.String(r.dbSnapshotName(ID))
+	}
+
+	return deleteDBInstanceInput
+}
+
+func (r *RDSDBInstance) dbSnapshotName(ID string) string {
+	return fmt.Sprintf("rds-broker-%s-%s", ID, time.Now().Format("2006-01-02-15-04-05"))
+}
+
+func (r *RDSDBInstance) dbInstanceARN(ID string) (string, error) {
+	userAccount, err := UserAccount(r.iamsvc)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("arn:aws:rds:%s:%s:db:%s", r.region, userAccount, ID), nil
+}
+
+func (r *RDSDBInstance) allowMajorVersionUpgrade(newEngineVersion, oldEngineVersion string) bool {
+	newSplittedEngineVersion := strings.Split(newEngineVersion, ".")
+	newMajorEngineVersion := fmt.Sprintf("%s:%s", newSplittedEngineVersion[0], newSplittedEngineVersion[1])
+
+	oldSplittedEngineVersion := strings.Split(oldEngineVersion, ".")
+	oldMajorEngineVersion := fmt.Sprintf("%s:%s", oldSplittedEngineVersion[0], oldSplittedEngineVersion[1])
+
+	if newMajorEngineVersion > oldMajorEngineVersion {
+		return true
+	}
+
+	return false
+}

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -1,0 +1,1104 @@
+package awsrds_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/awsrds"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pivotal-golang/lager"
+	"github.com/pivotal-golang/lager/lagertest"
+)
+
+var _ = Describe("RDS DB Instance", func() {
+	var (
+		region               string
+		dbInstanceIdentifier string
+
+		awsSession *session.Session
+
+		iamsvc  *iam.IAM
+		iamCall func(r *request.Request)
+
+		rdssvc  *rds.RDS
+		rdsCall func(r *request.Request)
+
+		testSink *lagertest.TestSink
+		logger   lager.Logger
+
+		rdsDBInstance DBInstance
+	)
+
+	BeforeEach(func() {
+		region = "rds-region"
+		dbInstanceIdentifier = "cf-instance-id"
+	})
+
+	JustBeforeEach(func() {
+		awsSession = session.New(nil)
+
+		iamsvc = iam.New(awsSession)
+		rdssvc = rds.New(awsSession)
+
+		logger = lager.NewLogger("rdsdbinstance_test")
+		testSink = lagertest.NewTestSink()
+		logger.RegisterSink(testSink)
+
+		rdsDBInstance = NewRDSDBInstance(region, iamsvc, rdssvc, logger)
+	})
+
+	var _ = Describe("Describe", func() {
+		var (
+			properDBInstanceDetails DBInstanceDetails
+
+			describeDBInstances []*rds.DBInstance
+			describeDBInstance  *rds.DBInstance
+
+			describeDBInstancesInput *rds.DescribeDBInstancesInput
+			describeDBInstanceError  error
+		)
+
+		BeforeEach(func() {
+			properDBInstanceDetails = DBInstanceDetails{
+				Identifier:       dbInstanceIdentifier,
+				Status:           "available",
+				Engine:           "test-engine",
+				EngineVersion:    "1.2.3",
+				DBName:           "test-dbname",
+				MasterUsername:   "test-master-username",
+				AllocatedStorage: int64(100),
+			}
+
+			describeDBInstance = &rds.DBInstance{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				DBInstanceStatus:     aws.String("available"),
+				Engine:               aws.String("test-engine"),
+				EngineVersion:        aws.String("1.2.3"),
+				DBName:               aws.String("test-dbname"),
+				MasterUsername:       aws.String("test-master-username"),
+				AllocatedStorage:     aws.Int64(100),
+			}
+			describeDBInstances = []*rds.DBInstance{describeDBInstance}
+
+			describeDBInstancesInput = &rds.DescribeDBInstancesInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+			}
+			describeDBInstanceError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("DescribeDBInstances"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&rds.DescribeDBInstancesInput{}))
+				Expect(r.Params).To(Equal(describeDBInstancesInput))
+				data := r.Data.(*rds.DescribeDBInstancesOutput)
+				data.DBInstances = describeDBInstances
+				r.Error = describeDBInstanceError
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+		})
+
+		It("returns the proper DB Instance", func() {
+			dbInstanceDetails, err := rdsDBInstance.Describe(dbInstanceIdentifier)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dbInstanceDetails).To(Equal(properDBInstanceDetails))
+		})
+
+		Context("when RDS DB Instance has an Endpoint", func() {
+			BeforeEach(func() {
+				describeDBInstance.Endpoint = &rds.Endpoint{
+					Address: aws.String("dbinstance-endpoint"),
+					Port:    aws.Int64(3306),
+				}
+
+				properDBInstanceDetails.Address = "dbinstance-endpoint"
+				properDBInstanceDetails.Port = int64(3306)
+			})
+
+			It("returns the proper DB Instance", func() {
+				dbInstanceDetails, err := rdsDBInstance.Describe(dbInstanceIdentifier)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dbInstanceDetails).To(Equal(properDBInstanceDetails))
+			})
+		})
+
+		Context("when RDS DB Instance has pending modifications", func() {
+			BeforeEach(func() {
+				describeDBInstance.PendingModifiedValues = &rds.PendingModifiedValues{
+					DBInstanceClass: aws.String("new-instance-class"),
+				}
+				properDBInstanceDetails.PendingModifications = true
+			})
+
+			It("returns the proper DB Instance", func() {
+				dbInstanceDetails, err := rdsDBInstance.Describe(dbInstanceIdentifier)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dbInstanceDetails).To(Equal(properDBInstanceDetails))
+			})
+		})
+
+		Context("when the DB instance does not exists", func() {
+			JustBeforeEach(func() {
+				describeDBInstancesInput = &rds.DescribeDBInstancesInput{
+					DBInstanceIdentifier: aws.String("unknown"),
+				}
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsDBInstance.Describe("unknown")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(ErrDBInstanceDoesNotExist))
+			})
+		})
+
+		Context("when describing the DB instance fails", func() {
+			BeforeEach(func() {
+				describeDBInstanceError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsDBInstance.Describe(dbInstanceIdentifier)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					describeDBInstanceError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsDBInstance.Describe(dbInstanceIdentifier)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+
+			Context("and it is a 404 error", func() {
+				BeforeEach(func() {
+					awsError := awserr.New("code", "message", errors.New("operation failed"))
+					describeDBInstanceError = awserr.NewRequestFailure(awsError, 404, "request-id")
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsDBInstance.Describe(dbInstanceIdentifier)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(ErrDBInstanceDoesNotExist))
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Create", func() {
+		var (
+			dbInstanceDetails DBInstanceDetails
+
+			createDBInstanceInput *rds.CreateDBInstanceInput
+			createDBInstanceError error
+		)
+
+		BeforeEach(func() {
+			dbInstanceDetails = DBInstanceDetails{
+				Engine: "test-engine",
+			}
+
+			createDBInstanceInput = &rds.CreateDBInstanceInput{
+				DBInstanceIdentifier:    aws.String(dbInstanceIdentifier),
+				Engine:                  aws.String("test-engine"),
+				AutoMinorVersionUpgrade: aws.Bool(false),
+				CopyTagsToSnapshot:      aws.Bool(false),
+				MultiAZ:                 aws.Bool(false),
+				PubliclyAccessible:      aws.Bool(false),
+				StorageEncrypted:        aws.Bool(false),
+			}
+			createDBInstanceError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("CreateDBInstance"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&rds.CreateDBInstanceInput{}))
+				Expect(r.Params).To(Equal(createDBInstanceInput))
+				r.Error = createDBInstanceError
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+		})
+
+		It("does not return error", func() {
+			err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when has AllocatedStorage", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.AllocatedStorage = 100
+				createDBInstanceInput.AllocatedStorage = aws.Int64(100)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has AutoMinorVersionUpgrade", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.AutoMinorVersionUpgrade = true
+				createDBInstanceInput.AutoMinorVersionUpgrade = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has AvailabilityZone", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.AvailabilityZone = "test-az"
+				createDBInstanceInput.AvailabilityZone = aws.String("test-az")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has BackupRetentionPeriod", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.BackupRetentionPeriod = 7
+				createDBInstanceInput.BackupRetentionPeriod = aws.Int64(7)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has CharacterSetName", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.CharacterSetName = "test-characterset-name"
+				createDBInstanceInput.CharacterSetName = aws.String("test-characterset-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has CopyTagsToSnapshot", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.CopyTagsToSnapshot = true
+				createDBInstanceInput.CopyTagsToSnapshot = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBClusterIdentifier", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBClusterIdentifier = "test-db-cluster-identifier"
+				createDBInstanceInput.DBClusterIdentifier = aws.String("test-db-cluster-identifier")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBInstanceClass", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBInstanceClass = "db.m3.small"
+				createDBInstanceInput.DBInstanceClass = aws.String("db.m3.small")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBName", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBName = "test-dbname"
+				createDBInstanceInput.DBName = aws.String("test-dbname")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBParameterGroupName", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBParameterGroupName = "test-db-parameter-group-name"
+				createDBInstanceInput.DBParameterGroupName = aws.String("test-db-parameter-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBSecurityGroups", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBSecurityGroups = []string{"test-db-security-group"}
+				createDBInstanceInput.DBSecurityGroups = aws.StringSlice([]string{"test-db-security-group"})
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBSubnetGroupName", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBSubnetGroupName = "test-db-subnet-group-name"
+				createDBInstanceInput.DBSubnetGroupName = aws.String("test-db-subnet-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has EngineVersion", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.EngineVersion = "1.2.3"
+				createDBInstanceInput.EngineVersion = aws.String("1.2.3")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has KmsKeyID", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.KmsKeyID = "test-kms-key-id"
+				createDBInstanceInput.KmsKeyId = aws.String("test-kms-key-id")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has MasterUsername", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.MasterUsername = "test-master-username"
+				createDBInstanceInput.MasterUsername = aws.String("test-master-username")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has MasterUserPassword", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.MasterUserPassword = "test-master-user-password"
+				createDBInstanceInput.MasterUserPassword = aws.String("test-master-user-password")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has LicenseModel", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.LicenseModel = "test-license-model"
+				createDBInstanceInput.LicenseModel = aws.String("test-license-model")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has MultiAZ", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.MultiAZ = true
+				createDBInstanceInput.MultiAZ = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has OptionGroupName", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.OptionGroupName = "test-option-group-name"
+				createDBInstanceInput.OptionGroupName = aws.String("test-option-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Port", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.Port = 666
+				createDBInstanceInput.Port = aws.Int64(666)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredBackupWindow", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.PreferredBackupWindow = "test-preferred-backup-window"
+				createDBInstanceInput.PreferredBackupWindow = aws.String("test-preferred-backup-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredMaintenanceWindow", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.PreferredMaintenanceWindow = "test-preferred-maintenance-window"
+				createDBInstanceInput.PreferredMaintenanceWindow = aws.String("test-preferred-maintenance-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PubliclyAccessible", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.PubliclyAccessible = true
+				createDBInstanceInput.PubliclyAccessible = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has StorageEncrypted", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.StorageEncrypted = true
+				createDBInstanceInput.StorageEncrypted = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has StorageType", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.StorageType = "test-storage-type"
+				createDBInstanceInput.StorageType = aws.String("test-storage-type")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Iops", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.Iops = 1000
+				createDBInstanceInput.Iops = aws.Int64(1000)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has VpcSecurityGroupIds", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.VpcSecurityGroupIds = []string{"test-vpc-security-group-ids"}
+				createDBInstanceInput.VpcSecurityGroupIds = aws.StringSlice([]string{"test-vpc-security-group-ids"})
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Tags", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.Tags = map[string]string{"Owner": "Cloud Foundry"}
+				createDBInstanceInput.Tags = []*rds.Tag{
+					&rds.Tag{Key: aws.String("Owner"), Value: aws.String("Cloud Foundry")},
+				}
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when creating the DB Instance fails", func() {
+			BeforeEach(func() {
+				createDBInstanceError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					createDBInstanceError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBInstance.Create(dbInstanceIdentifier, dbInstanceDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Modify", func() {
+		var (
+			dbInstanceDetails DBInstanceDetails
+			applyImmediately  bool
+
+			describeDBInstances []*rds.DBInstance
+			describeDBInstance  *rds.DBInstance
+
+			describeDBInstancesInput *rds.DescribeDBInstancesInput
+			describeDBInstanceError  error
+
+			modifyDBInstanceInput *rds.ModifyDBInstanceInput
+			modifyDBInstanceError error
+
+			addTagsToResourceInput *rds.AddTagsToResourceInput
+			addTagsToResourceError error
+
+			user         *iam.User
+			getUserInput *iam.GetUserInput
+			getUserError error
+		)
+
+		BeforeEach(func() {
+			dbInstanceDetails = DBInstanceDetails{}
+			applyImmediately = false
+
+			describeDBInstance = &rds.DBInstance{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				DBInstanceStatus:     aws.String("available"),
+				Engine:               aws.String("test-engine"),
+				EngineVersion:        aws.String("1.2.3"),
+				DBName:               aws.String("test-dbname"),
+				MasterUsername:       aws.String("test-master-username"),
+				AllocatedStorage:     aws.Int64(100),
+			}
+			describeDBInstances = []*rds.DBInstance{describeDBInstance}
+
+			describeDBInstancesInput = &rds.DescribeDBInstancesInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+			}
+			describeDBInstanceError = nil
+
+			modifyDBInstanceInput = &rds.ModifyDBInstanceInput{
+				DBInstanceIdentifier:    aws.String(dbInstanceIdentifier),
+				ApplyImmediately:        aws.Bool(applyImmediately),
+				AutoMinorVersionUpgrade: aws.Bool(false),
+				CopyTagsToSnapshot:      aws.Bool(false),
+				MultiAZ:                 aws.Bool(false),
+			}
+			modifyDBInstanceError = nil
+
+			addTagsToResourceInput = &rds.AddTagsToResourceInput{
+				ResourceName: aws.String("arn:aws:rds:rds-region:account:db:" + dbInstanceIdentifier),
+				Tags: []*rds.Tag{
+					&rds.Tag{
+						Key:   aws.String("Owner"),
+						Value: aws.String("Cloud Foundry"),
+					},
+				},
+			}
+			addTagsToResourceError = nil
+
+			user = &iam.User{
+				Arn: aws.String("arn:aws:service:region:account:resource"),
+			}
+			getUserInput = &iam.GetUserInput{}
+			getUserError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(MatchRegexp("DescribeDBInstances|ModifyDBInstance|AddTagsToResource"))
+				switch r.Operation.Name {
+				case "DescribeDBInstances":
+					Expect(r.Operation.Name).To(Equal("DescribeDBInstances"))
+					Expect(r.Params).To(BeAssignableToTypeOf(&rds.DescribeDBInstancesInput{}))
+					Expect(r.Params).To(Equal(describeDBInstancesInput))
+					data := r.Data.(*rds.DescribeDBInstancesOutput)
+					data.DBInstances = describeDBInstances
+					r.Error = describeDBInstanceError
+				case "ModifyDBInstance":
+					Expect(r.Params).To(BeAssignableToTypeOf(&rds.ModifyDBInstanceInput{}))
+					Expect(r.Params).To(Equal(modifyDBInstanceInput))
+					r.Error = modifyDBInstanceError
+				case "AddTagsToResource":
+					Expect(r.Params).To(BeAssignableToTypeOf(&rds.AddTagsToResourceInput{}))
+					Expect(r.Params).To(Equal(addTagsToResourceInput))
+					r.Error = addTagsToResourceError
+				}
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+
+			iamsvc.Handlers.Clear()
+			iamCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("GetUser"))
+				Expect(r.Params).To(Equal(getUserInput))
+				data := r.Data.(*iam.GetUserOutput)
+				data.User = user
+				r.Error = getUserError
+			}
+			iamsvc.Handlers.Send.PushBack(iamCall)
+		})
+
+		It("does not return error", func() {
+			err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when apply immediately is set to true", func() {
+			BeforeEach(func() {
+				applyImmediately = true
+				modifyDBInstanceInput.ApplyImmediately = aws.Bool(true)
+			})
+
+			It("returns the proper DB Instance", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when is a different DB engine", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.Engine = "new-engine"
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Migrating the RDS DB Instance engine from 'test-engine' to 'new-engine' is not supported"))
+			})
+		})
+
+		Context("when has AllocatedStorage", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.AllocatedStorage = 500
+				modifyDBInstanceInput.AllocatedStorage = aws.Int64(500)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("and new value is less than old value", func() {
+				BeforeEach(func() {
+					dbInstanceDetails.AllocatedStorage = 50
+					modifyDBInstanceInput.AllocatedStorage = aws.Int64(100)
+				})
+
+				It("picks up the old value", func() {
+					err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has AutoMinorVersionUpgrade", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.AutoMinorVersionUpgrade = true
+				modifyDBInstanceInput.AutoMinorVersionUpgrade = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has BackupRetentionPeriod", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.BackupRetentionPeriod = 7
+				modifyDBInstanceInput.BackupRetentionPeriod = aws.Int64(7)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has CopyTagsToSnapshot", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.CopyTagsToSnapshot = true
+				modifyDBInstanceInput.CopyTagsToSnapshot = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBInstanceClass", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBInstanceClass = "db.m3.small"
+				modifyDBInstanceInput.DBInstanceClass = aws.String("db.m3.small")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBParameterGroupName", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBParameterGroupName = "test-db-parameter-group-name"
+				modifyDBInstanceInput.DBParameterGroupName = aws.String("test-db-parameter-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBSecurityGroups", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.DBSecurityGroups = []string{"test-db-security-group"}
+				modifyDBInstanceInput.DBSecurityGroups = aws.StringSlice([]string{"test-db-security-group"})
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has EngineVersion", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.EngineVersion = "1.2.4"
+				modifyDBInstanceInput.EngineVersion = aws.String("1.2.4")
+				modifyDBInstanceInput.AllowMajorVersionUpgrade = aws.Bool(false)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("and is a major version upgrade", func() {
+				BeforeEach(func() {
+					dbInstanceDetails.EngineVersion = "1.3.3"
+					modifyDBInstanceInput.EngineVersion = aws.String("1.3.3")
+					modifyDBInstanceInput.AllowMajorVersionUpgrade = aws.Bool(true)
+				})
+
+				It("does not return error", func() {
+					err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has MultiAZ", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.MultiAZ = true
+				modifyDBInstanceInput.MultiAZ = aws.Bool(true)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has OptionGroupName", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.OptionGroupName = "test-option-group-name"
+				modifyDBInstanceInput.OptionGroupName = aws.String("test-option-group-name")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredBackupWindow", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.PreferredBackupWindow = "test-preferred-backup-window"
+				modifyDBInstanceInput.PreferredBackupWindow = aws.String("test-preferred-backup-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has PreferredMaintenanceWindow", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.PreferredMaintenanceWindow = "test-preferred-maintenance-window"
+				modifyDBInstanceInput.PreferredMaintenanceWindow = aws.String("test-preferred-maintenance-window")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has StorageType", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.StorageType = "test-storage-type"
+				modifyDBInstanceInput.StorageType = aws.String("test-storage-type")
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Iops", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.Iops = 1000
+				modifyDBInstanceInput.Iops = aws.Int64(1000)
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has VpcSecurityGroupIds", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.VpcSecurityGroupIds = []string{"test-vpc-security-group-ids"}
+				modifyDBInstanceInput.VpcSecurityGroupIds = aws.StringSlice([]string{"test-vpc-security-group-ids"})
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Tags", func() {
+			BeforeEach(func() {
+				dbInstanceDetails.Tags = map[string]string{"Owner": "Cloud Foundry"}
+			})
+
+			It("does not return error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when adding tags to resource fails", func() {
+				BeforeEach(func() {
+					addTagsToResourceError = errors.New("operation failed")
+				})
+
+				It("does not return error", func() {
+					err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when getting user arn fails", func() {
+				BeforeEach(func() {
+					getUserError = errors.New("operation failed")
+				})
+
+				It("does not return error", func() {
+					err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when describing the DB instance fails", func() {
+			BeforeEach(func() {
+				describeDBInstanceError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+		})
+
+		Context("when modifying the DB instance fails", func() {
+			BeforeEach(func() {
+				modifyDBInstanceError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					modifyDBInstanceError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Delete", func() {
+		var (
+			skipFinalSnapshot         bool
+			finalDBSnapshotIdentifier string
+
+			deleteDBInstanceError error
+		)
+
+		BeforeEach(func() {
+			skipFinalSnapshot = true
+			finalDBSnapshotIdentifier = ""
+			deleteDBInstanceError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("DeleteDBInstance"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&rds.DeleteDBInstanceInput{}))
+				params := r.Params.(*rds.DeleteDBInstanceInput)
+				Expect(params.DBInstanceIdentifier).To(Equal(aws.String(dbInstanceIdentifier)))
+				if finalDBSnapshotIdentifier != "" {
+					Expect(*params.FinalDBSnapshotIdentifier).To(ContainSubstring(finalDBSnapshotIdentifier))
+				} else {
+					Expect(params.FinalDBSnapshotIdentifier).To(BeNil())
+				}
+				Expect(params.SkipFinalSnapshot).To(Equal(aws.Bool(skipFinalSnapshot)))
+				r.Error = deleteDBInstanceError
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+		})
+
+		It("does not return error", func() {
+			err := rdsDBInstance.Delete(dbInstanceIdentifier, skipFinalSnapshot)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when does not skip the final snapshot", func() {
+			BeforeEach(func() {
+				skipFinalSnapshot = false
+				finalDBSnapshotIdentifier = "rds-broker-" + dbInstanceIdentifier
+			})
+
+			It("returns the proper DB Instance", func() {
+				err := rdsDBInstance.Delete(dbInstanceIdentifier, skipFinalSnapshot)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when deleting the DB instance fails", func() {
+			BeforeEach(func() {
+				deleteDBInstanceError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsDBInstance.Delete(dbInstanceIdentifier, skipFinalSnapshot)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					deleteDBInstanceError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBInstance.Delete(dbInstanceIdentifier, skipFinalSnapshot)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+
+			Context("and it is a 404 error", func() {
+				BeforeEach(func() {
+					awsError := awserr.New("code", "message", errors.New("operation failed"))
+					deleteDBInstanceError = awserr.NewRequestFailure(awsError, 404, "request-id")
+				})
+
+				It("returns the proper error", func() {
+					err := rdsDBInstance.Delete(dbInstanceIdentifier, skipFinalSnapshot)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(ErrDBInstanceDoesNotExist))
+				})
+			})
+		})
+	})
+})

--- a/awsrds/utils.go
+++ b/awsrds/utils.go
@@ -1,0 +1,56 @@
+package awsrds
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pivotal-golang/lager"
+)
+
+func UserAccount(iamsvc *iam.IAM) (string, error) {
+	getUserInput := &iam.GetUserInput{}
+	getUserOutput, err := iamsvc.GetUser(getUserInput)
+	if err != nil {
+		return "", err
+	}
+
+	userAccount := strings.Split(*getUserOutput.User.Arn, ":")
+
+	return userAccount[4], nil
+}
+
+func BuilRDSTags(tags map[string]string) []*rds.Tag {
+	var rdsTags []*rds.Tag
+
+	for key, value := range tags {
+		rdsTags = append(rdsTags, &rds.Tag{Key: aws.String(key), Value: aws.String(value)})
+	}
+
+	return rdsTags
+}
+
+func AddTagsToResource(resourceARN string, tags []*rds.Tag, rdssvc *rds.RDS, logger lager.Logger) error {
+	addTagsToResourceInput := &rds.AddTagsToResourceInput{
+		ResourceName: aws.String(resourceARN),
+		Tags:         tags,
+	}
+
+	logger.Debug("add-tags-to-resource", lager.Data{"input": addTagsToResourceInput})
+
+	addTagsToResourceOutput, err := rdssvc.AddTagsToResource(addTagsToResourceInput)
+	if err != nil {
+		logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return err
+	}
+
+	logger.Debug("add-tags-to-resource", lager.Data{"output": addTagsToResourceOutput})
+
+	return nil
+}

--- a/awsrds/utils_test.go
+++ b/awsrds/utils_test.go
@@ -1,0 +1,180 @@
+package awsrds_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/awsrds"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pivotal-golang/lager"
+	"github.com/pivotal-golang/lager/lagertest"
+)
+
+var _ = Describe("RDS Utils", func() {
+	var (
+		awsSession *session.Session
+
+		iamsvc  *iam.IAM
+		iamCall func(r *request.Request)
+
+		rdssvc  *rds.RDS
+		rdsCall func(r *request.Request)
+
+		testSink *lagertest.TestSink
+		logger   lager.Logger
+	)
+
+	BeforeEach(func() {
+		awsSession = session.New(nil)
+
+		iamsvc = iam.New(awsSession)
+		rdssvc = rds.New(awsSession)
+
+		logger = lager.NewLogger("rdsservice_test")
+		testSink = lagertest.NewTestSink()
+		logger.RegisterSink(testSink)
+	})
+
+	var _ = Describe("UserAccount", func() {
+		var (
+			user         *iam.User
+			getUserInput *iam.GetUserInput
+			getUserError error
+		)
+
+		BeforeEach(func() {
+			user = &iam.User{
+				Arn: aws.String("arn:aws:service:region:account:resource"),
+			}
+			getUserInput = &iam.GetUserInput{}
+			getUserError = nil
+		})
+
+		JustBeforeEach(func() {
+			iamsvc.Handlers.Clear()
+			iamCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("GetUser"))
+				Expect(r.Params).To(Equal(getUserInput))
+				data := r.Data.(*iam.GetUserOutput)
+				data.User = user
+				r.Error = getUserError
+			}
+			iamsvc.Handlers.Send.PushBack(iamCall)
+		})
+
+		It("returns the User Account", func() {
+			userAccount, err := UserAccount(iamsvc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(userAccount).To(Equal("account"))
+		})
+
+		Context("when getting user fails", func() {
+			BeforeEach(func() {
+				getUserError = errors.New("operation failed")
+			})
+
+			It("return error the proper error", func() {
+				_, err := UserAccount(iamsvc)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+		})
+	})
+
+	var _ = Describe("BuilRDSTags", func() {
+		var (
+			tags          map[string]string
+			properRDSTags []*rds.Tag
+		)
+
+		BeforeEach(func() {
+			tags = map[string]string{"Owner": "Cloud Foundry"}
+			properRDSTags = []*rds.Tag{
+				&rds.Tag{
+					Key:   aws.String("Owner"),
+					Value: aws.String("Cloud Foundry"),
+				},
+			}
+		})
+
+		It("returns the proper RDS Tags", func() {
+			rdsTags := BuilRDSTags(tags)
+			Expect(rdsTags).To(Equal(properRDSTags))
+		})
+	})
+
+	var _ = Describe("AddTagsToResource", func() {
+		var (
+			resourceARN string
+			rdsTags     []*rds.Tag
+
+			addTagsToResourceInput *rds.AddTagsToResourceInput
+			addTagsToResourceError error
+		)
+
+		BeforeEach(func() {
+			resourceARN = "arn:aws:rds:rds-region:account:db:identifier"
+			rdsTags = []*rds.Tag{
+				&rds.Tag{
+					Key:   aws.String("Owner"),
+					Value: aws.String("Cloud Foundry"),
+				},
+			}
+
+			addTagsToResourceInput = &rds.AddTagsToResourceInput{
+				ResourceName: aws.String(resourceARN),
+				Tags:         rdsTags,
+			}
+			addTagsToResourceError = nil
+		})
+
+		JustBeforeEach(func() {
+			rdssvc.Handlers.Clear()
+
+			rdsCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("AddTagsToResource"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&rds.AddTagsToResourceInput{}))
+				Expect(r.Params).To(Equal(addTagsToResourceInput))
+				r.Error = addTagsToResourceError
+			}
+			rdssvc.Handlers.Send.PushBack(rdsCall)
+		})
+
+		It("does not return error", func() {
+			err := AddTagsToResource(resourceARN, rdsTags, rdssvc, logger)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when adding tags to a resource fails", func() {
+			BeforeEach(func() {
+				addTagsToResourceError = errors.New("operation failed")
+			})
+
+			It("return error the proper error", func() {
+				err := AddTagsToResource(resourceARN, rdsTags, rdssvc, logger)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("and it is an AWS error", func() {
+				BeforeEach(func() {
+					addTagsToResourceError = awserr.New("code", "message", errors.New("operation failed"))
+				})
+
+				It("returns the proper error", func() {
+					err := AddTagsToResource(resourceARN, rdsTags, rdssvc, logger)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("code: message"))
+				})
+			})
+		})
+	})
+})

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/cf-platform-eng/sqs-broker/rdsbroker"
 	"github.com/cf-platform-eng/sqs-broker/sqsbroker"
 )
 
@@ -14,7 +15,9 @@ type Config struct {
 	LogLevel  string           `json:"log_level"`
 	Username  string           `json:"username"`
 	Password  string           `json:"password"`
+	Region    string           `json:"region"`
 	SQSConfig sqsbroker.Config `json:"sqs_config"`
+	RDSConfig rdsbroker.Config `json:"rds_config"`
 }
 
 func LoadConfig(configFile string) (config *Config, err error) {
@@ -57,9 +60,17 @@ func (c Config) Validate() error {
 		return errors.New("Must provide a non-empty Password")
 	}
 
+	if c.Region == "" {
+		return errors.New("Must provide a non-empty Region")
+	}
+
 	if err := c.SQSConfig.Validate(); err != nil {
 		return fmt.Errorf("Validating SQS configuration: %s", err)
 	}
+
+	//if err := c.RDSConfig.Validate(); err != nil {
+	//		return fmt.Errorf("Validating SQS configuration: %s", err)
+	//}
 
 	return nil
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,292 @@
+{
+  "log_level": "DEBUG",
+  "username": "user",
+  "password": "pass",
+  "region": "us-east-1",
+  "rds_config": {
+    "RDS_prefix": "cf",
+    "region": "us-east-1",
+    "allow_user_provision_parameters": true,
+    "allow_user_update_parameters": true,
+    "catalog": {
+      "services": [
+        {
+          "id": "db80ca29-2d1b-4fbc-aad3-d03c0bfa7593",
+          "name": "RDS",
+          "description": "RDS Database Broker",
+          "bindable": true,
+          "tags": [
+            "database",
+            "RDS",
+            "postgresql",
+            "mysql"
+          ],
+          "metadata": {
+            "displayName": "RDS Database Broker",
+            "imageUrl": null,
+            "longDescription": null,
+            "providerDisplayName": "RDS",
+            "documentationUrl": null,
+            "supportUrl": null
+          },
+          "plans": [
+            {
+              "id": "44d24fc7-f7a4-4ac1-b7a0-de82836e89a3",
+              "name": "shared-psql",
+              "description": "Shared infrastructure for Postgres DB",
+              "tags": {
+                "environment": "cf-env",
+                "client": "the client",
+                "service": "aws-broker"
+              },
+              "metadata": {
+                "bullets": [
+                  "Shared RDS Instance",
+                  "Postgres instance"
+                ],
+                "costs": [
+                  {
+                    "amount": {
+                      "usd": 0
+                    },
+                    "unit": "MONTHLY"
+                  }
+                ],
+                "displayName": "Free Shared Plan"
+              },
+              "free": true,
+              "rds_properties": {
+                "adapter": "shared",
+                "dbType": "postgres",
+                "securityGroup": "sg-123456",
+                "subnetGroup": "subnet-group"
+              }
+            },
+            {
+              "id": "da91e15c-98c9-46a9-b114-02b8d28062c6",
+              "name": "micro-psql",
+              "description": "Dedicated Micro RDS Postgres DB Instance",
+              "tags": {
+                "environment": "cf-env",
+                "client": "the client",
+                "service": "aws-broker"
+              },
+              "metadata": {
+                "bullets": [
+                  "Dedicated Redundant RDS Instance",
+                  "Postgres instance"
+                ],
+                "costs": [
+                  {
+                    "amount": {
+                      "usd": 0.036
+                    },
+                    "unit": "HOURLY"
+                  }
+                ],
+                "displayName": "Dedicated Micro Postgres"
+              },
+              "free": false,
+              "rds_properties": {
+                "adapter": "dedicated",
+                "instanceClass": "db.t2.micro",
+                "dbType": "postgres",
+                "securityGroup": "sg-123456",
+                "subnetGroup": "subnet-group"
+              }
+            },
+            {
+              "id": "332e0168-6969-4bd7-b07f-29f08c4bf78e",
+              "name": "medium-psql",
+              "description": "Dedicated Medium RDS Postgres DB Instance",
+              "tags": {
+                "environment": "cf-env",
+                "client": "the client",
+                "service": "aws-broker"
+              },
+              "metadata": {
+                "bullets": [
+                  "Dedicated Redundant RDS Instance",
+                  "Postgres instance"
+                ],
+                "costs": [
+                  {
+                    "amount": {
+                      "usd": 0.19
+                    },
+                    "unit": "HOURLY"
+                  }
+                ],
+                "displayName": "Dedicated Medium Postgres"
+              },
+              "free": false,
+              "rds_properties": {
+                "adapter": "dedicated",
+                "instanceClass": "db.m3.medium",
+                "dbType": "postgres",
+                "securityGroup": "sg-123456",
+                "subnetGroup": "subnet-group"
+              }
+            },
+            {
+              "id": "44d24fc7-f7a4-4ac1-b7a0-de82836e89a4",
+              "name": "shared-mysql",
+              "description": "Shared infrastructure for MySQL DB",
+              "tags": {
+                "environment": "cf-env",
+                "client": "the client",
+                "service": "aws-broker"
+              },
+              "metadata": {
+                "bullets": [
+                  "Shared RDS Instance",
+                  "MySQL instance"
+                ],
+                "costs": [
+                  {
+                    "amount": {
+                      "usd": 0
+                    },
+                    "unit": "MONTHLY"
+                  }
+                ],
+                "displayName": "Free Shared Plan"
+              },
+              "free": true,
+              "rds_properties": {
+                "adapter": "shared",
+                "dbType": "mysql",
+                "securityGroup": "sg-123456",
+                "subnetGroup": "subnet-group"
+              }
+            },
+            {
+              "id": "da91e15c-98c9-46a9-b114-02b8d28062c7",
+              "name": "micro-mysql",
+              "description": "Dedicated Micro RDS Postgres DB Instance",
+              "tags": {
+                "environment": "cf-env",
+                "client": "the client",
+                "service": "aws-broker"
+              },
+              "metadata": {
+                "bullets": [
+                  "Dedicated Redundant RDS Instance",
+                  "MySQL instance"
+                ],
+                "costs": [
+                  {
+                    "amount": {
+                      "usd": 0.036
+                    },
+                    "unit": "HOURLY"
+                  }
+                ],
+                "displayName": "Dedicated Micro MySQL"
+              },
+              "free": false,
+              "rds_properties": {
+                "adapter": "dedicated",
+                "instanceClass": "db.t2.micro",
+                "dbType": "mysql",
+                "securityGroup": "sg-123456",
+                "subnetGroup": "subnet-group"
+              }
+            },
+            {
+              "id": "332e0168-6969-4bd7-b07f-29f08c4bf78d",
+              "name": "medium-mysql",
+              "description": "Dedicated Medium RDS MySQL DB Instance",
+              "tags": {
+                "environment": "cf-env",
+                "client": "the client",
+                "service": "aws-broker"
+              },
+              "metadata": {
+                "bullets": [
+                  "Dedicated Redundant RDS Instance",
+                  "MySQL instance"
+                ],
+                "costs": [
+                  {
+                    "amount": {
+                      "usd": 0.19
+                    },
+                    "unit": "HOURLY"
+                  }
+                ],
+                "displayName": "Dedicated Medium MySQL"
+              },
+              "free": false,
+              "rds_properties": {
+                "adapter": "dedicated",
+                "instanceClass": "db.m3.medium",
+                "dbType": "mysql",
+                "securityGroup": "sg-123456",
+                "subnetGroup": "subnet-group"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "sqs_config": {
+    "region": "us-east-1",
+    "sqs_prefix": "cf",
+    "allow_user_provision_parameters": true,
+    "allow_user_update_parameters": true,
+    "catalog": {
+      "services": [
+        {
+          "id": "3c5ff4fd-3a27-4e66-a94d-f7d38558405d",
+          "name": "awssqs",
+          "description": "AWS SQS service",
+          "bindable": true,
+          "tags": [
+            "sqs",
+            "jms"
+          ],
+          "metadata": {
+            "displayName": "AWS SQS",
+            "imageUrl": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAKE0lEQVR42u1be1BU1xnHTh+Zdib/dJoAPngtlPgossAuEcQHqRVB61hFtBgRlJeSQFRENF2j8nJZQKs8piqNymN5RIsi8RE1GjOdltLGx7J3L+KjY5KpMTY2BoHd+/U75+4LZGFh72IAd+abvXtZdu/vd36/73zf3XMcHIb/MY5ERcEySUHatLNMTUjjnQ/jxYbzDqP4QQEey4sMzH97SlN2wiRdXpI7p64K4JhKX62mNvgvd8+s9RuNRPDAFQg8ddppAjw30Z3LTXTj8pLdgakKAE21P8dUEyLESETIibsXRgcRFMAReZRUgcCz4k3Ac5PcgYSJAEOYEzHzxEhVhBG4Qeq9gVsmwJwIf0oE5ogRYw0zj09tyuoH+MAE9KWI72+OoBdUjsAVqVNOZ1sB3HoCLFjje5IjTFKnyW2i1cAHT0Bf1kBFPCcizDxundSFI+BZRQxnjujhcSr1JHfdUIDbTsDw5giL8/hQgQtHQF9ECFdH0A8ofjd0pqV53OZAAtSVQhBghzqiVDY3ZE+K94WcBBcuR0Dg+FkYbjj6bkiAJ1w/KoX2WnrxAqnBYh1h/WN33IQNvL+FAU5A5yYR0B6QnegF29Z4Qcoyd4iLmACxGNtiPKHyPV9oLpfArRoJsEpChhCE8IpQV/l2sx/Mj7aagJ1rHNPzkjw420C76UGLYGfCLyF9lSckLXGFNQucMZwgNtzZGHEYMWFO8OZ8J0iNcoeS9GnwcXEAEiFFQgJsJoOp8tOpa+ckW03AjljHLYMlwCRtdypt2VovSFshgnWLJvYJ2lIQMsh7CRkJiydB3vrJ0KjwgxvHiFUkeqv4D5YAjqmbvV5wAkyjjMdJBmm7UWmTEY21EnT/QchwNLPKdGgplw7KKoISYC7tXfFesDlaZFHaQofJKs6Qupy3yuWSga1iMwF5xlEWgSyOSNtDL20nu4MeyCqrfuMEic9YpeesYhMBBLgidTqkRYkgZsF4iJ7nCKtRkuTLyUXERTg/FwIsWiV8AmxHq1Tt9IWWP0s5tAqHVtEOOQkqUjzgTh3xWyBcOyJFyfnDiTw/+FOmD05p3rBppRuOgAusDhuPo+FIL4JXhZPdycHv4dB6HB7r4iLG62LCHLkYPBcT9opu1byf6zCRchtXih4pc2aoWo7NWzpkAkjCYaiUDD7zBxYlRnzHZ2YJXDsqgatlUmiQi+FQ5lScCbwhPdqTyjMG8wPJ6oQcvEhewhFWAgznASKhOvJ69fxXEOCrutXzf6Fbg+fWLpr0KP63Ljc3RHo3rY987VDiEo/0zHVBkQpZ9IyMxNmuNTWyHw+6CuyLgH6zrEVyAqCtJhB9GQiflvnDSSSnfPt0kG+YDBmrPCg5axZMMCqHJDgCMoaAW/AqBRy3cMJXSUs9b65b7NqI4EpTV07dlLbCJ1KeESWtOrBtYkqY6CfkmmUy2Q/MS14AG3qBwRJgefrhQ60nh8Vz7UgMsRRRjqoiAMmRwF8PSuF0gT9X/ofp/1s93+mt7cnzlqbHzZSkbwhybi4r+xEBInNw6AFQJuv5WtCHtQQYAFqah1UVfvCPw2K4XOwDjfKpUL3zNTiY4QX7UkUgX88XT6QZUhPlYNmK//Otpm7OHrUyOPZOU1To/U+3erOnf/+yYUT1o+rQ1+thI4BVBuiLEALQH1oO+8InJT5w8Y+/oufIe4j8S9M9ac2QlcBHNqkfEgduh8mUpcHSlan01TFVvkiKpENTLb3N1oZcYmtnVWiUQTvZurnR/z6fPKftw2jR/eb4n/YlebtYgAA8hSO5f6MI8jd4GAFmYxRvEhnfR55LNnkJcD+AqIIqA8nAIM0NmdMrxTqmYrqO/q0q4LGmdoZGUzf7oqY2+H2NMnhLW8PiFXebVgS3N650uX27/CXBCGhDAip3eD8LBKN0s2cPAooFIcC6tpcQhERQQjDXcFQ9VEFETZJHmtqZarbujchRSICVN0iqbCyERi4BApTCLwh4QcALAl4Q8IKAET0N+o/madA4z+v4YshUKaorfEgZjcWQ5AumJrhF88EbSwQrhQ9gKazAUjh3GErhHgDpsZgvhbHSQ8BaRhn4QKN8/TO2bvZJtj70AKMMXt9+InzR/cubxar6JU7Qq00WtBlqxWbon+ViuFrqA5f292yGytK9nmmGcqxshnhwpCFCoNWBD7GUvcnWBDWwdSElTP2vN7L185bevZDkd++TPOeLstk/JAB7NT/jhuV+gHk73NdIkna4BQm6gu1wk2IqKLEdPrQV2+E0vh0mn2/6P+rXb7Hr28ieWrrsVsOSgHtn051v6O/o9O7/AWDcc78fYO0NEcZMPW1KPwwx4OjCjaN4XBsEdxrC4P7Z5dyDy4kPO1V7lndpyqRPb73vdfui7CV+NKHXvQCw71qAoREg0Qe5LeZHAaorfem5W3UhFOTnZ5fDgyvJ8M3ft8CTz96DTpUcupki0GJ0MwUkuG51vq6rNZ/rxuhU5T/uUikYfM/lrtbCI52t+RmdzL43u5nS0A7Vfhf48szP+r4dBrbdLNkRMzABBCB6lT4TkG31IXD3ZAR8fm4lfHUlgYLsuJ4FXRRkIQWpxWcECAgOECR97lYrLAWnD0KIjpzrasXXrXJ8LdfpP+O/XeqCdvzbeXw+3Kku2tWp2ruqi93/+tO2o6KH7L6XzW6OWP8oeHvadsOvwpQAlC1TLUWQsxBkOHxxPhoeXk2Bx82Z8N21XRSMltnLAyQjSS/WKpC2BEcJ0RNEjnnlGAiSa5H4jo7r2eovL8adv9WwMMLqhREHMmfk5ya6Gn8YOXdwGdy7+i50s/tA17YPQSmMo0hBqu0G0rowXAe1USE8+dcO+M/HsVz78VD9lCnWsvXWF0I9CKC/Bya4wu61E6EwdTIcLwqH1jMb4clNOWjZItOXDzNoA/HEWuT4m+YMkkgxqQbz1sQ8xOekwZfCzxDQO3avmwS5ySI4unsW/K0uHr5uyaZkaHEEeFXYE7SCWq3jRi58jTa8d2ohBcrQhCtMLzAgAaZCxgOy4l1olGz1g4/Ko6hVukjS0xSaWURAaV+Kg/bjbxhnGns0Q1YT0JuMnERX2EWskkassgCt8g58p8oflFWMOYXhCXzcvMUobTWVtr9R2vbqBscVbwuSo+9tXhuURayS5GFmlSzQtu3VW0VutIpJ2kXw9EYOnWHuNRqkLRaiHR7cEpn9mTO25MS7cMKtB9RbBZNpyVYxXChfYbRKT2mH8r8vCgDapkVSdJnctrkh8hTvj4ReJmdulaJ3pgBbO3PI0rbbMrnhWihJyBD2hoh9NlyYLZWdMqaWyvazBUZPxBhZLG2BiN/xy+Xjx85y+X43RQ3FGiN1w4RlIt6aMqidIyN9y4zFDRV01hhDm6b63zYXbzlZjrZtcxaT5VjbOGl1HTHat872u9tsLG2e7pMIsn2+MG3aOZzOnuv2+f8DVYlYb8i4ROEAAAAASUVORK5CYII=",
+            "longDescription": "AWS Simple Queue Service (SQS)",
+            "providerDisplayName": "Amazon Web Services",
+            "documentationUrl": "https://aws.amazon.com/documentation/sqs/",
+            "supportUrl": "https://forums.aws.amazon.com/forum.jspa?forumID=12"
+          },
+          "plan_updateable": true,
+          "plans": [
+            {
+              "id": "7105c0ec-5238-45d4-a08d-3d682fbb4587",
+              "name": "queue",
+              "description": "AWS SQS Queue",
+              "metadata": {
+                "costs": [
+                  {
+                    "amount": {
+                      "usd": 0.50
+                    },
+                    "unit": "per Million Requests"
+                  }
+                ],
+                "bullets": [
+                  "Dedicated AWS SQS queue",
+                  "AWS SQS"
+                ]
+              },
+              "free": false,
+              "sqs_properties": {
+                "delay_seconds": "0",
+                "maximum_message_size": "262144",
+                "message_retention_period": "345600",
+                "receive_message_wait_time_seconds": "0",
+                "visibility_timeout": "30"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/iam_policy.json
+++ b/iam_policy.json
@@ -28,6 +28,11 @@
       ],
       "Effect": "Allow",
       "Resource": "*"
+    },
+    {
+      "Action": "rds:CreateDBInstance",
+      "Effect": "Allow",
+      "Resource":"*"
     }
   ]
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"html"
 	"log"
 	"net/http"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/frodenas/brokerapi"
 	"github.com/pivotal-golang/lager"
@@ -18,6 +20,10 @@ import (
 	"github.com/cf-platform-eng/sqs-broker/awsiam"
 	"github.com/cf-platform-eng/sqs-broker/awssqs"
 	"github.com/cf-platform-eng/sqs-broker/sqsbroker"
+
+	"github.com/cf-platform-eng/sqs-broker/awsrds"
+	"github.com/cf-platform-eng/sqs-broker/rdsbroker"
+	"github.com/cf-platform-eng/sqs-broker/sqlengine"
 )
 
 var (
@@ -33,7 +39,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&configFilePath, "config", "", "Location of the config file")
+	flag.StringVar(&configFilePath, "config", "config.json", "Location of the config file")
 	flag.StringVar(&port, "port", "3000", "Listen port")
 }
 
@@ -43,10 +49,20 @@ func buildLogger(logLevel string) lager.Logger {
 		log.Fatal("Invalid log level: ", logLevel)
 	}
 
-	logger := lager.NewLogger("sqs-broker")
+	logger := lager.NewLogger("aws-broker")
+	// TODO: Proivde log destination as a config/env option
 	logger.RegisterSink(lager.NewWriterSink(os.Stdout, laggerLogLevel))
 
 	return logger
+}
+
+func HTTPHandler(w http.ResponseWriter, r *http.Request) {
+	switch html.EscapeString(r.URL.Path) {
+	case "/v2/catalog":
+		fmt.Println("Render full catalog")
+	default:
+		fmt.Println("Parse and route to correct broker")
+	}
 }
 
 func main() {
@@ -59,25 +75,51 @@ func main() {
 
 	logger := buildLogger(config.LogLevel)
 
-	awsConfig := aws.NewConfig().WithRegion(config.SQSConfig.Region)
+	awsConfig := aws.NewConfig().WithRegion(config.Region)
 	awsSession := session.New(awsConfig)
 
-	sqssvc := sqs.New(awsSession)
-	queue := awssqs.NewSQSQueue(sqssvc, logger)
-
 	iamsvc := iam.New(awsSession)
+	rdssvc := rds.New(awsSession)
+	sqssvc := sqs.New(awsSession)
+
+	queue := awssqs.NewSQSQueue(sqssvc, logger)
 	user := awsiam.NewIAMUser(iamsvc, logger)
 
-	serviceBroker := sqsbroker.New(config.SQSConfig, queue, user, logger)
+	dbInstance := awsrds.NewRDSDBInstance(config.RDSConfig.Region, iamsvc, rdssvc, logger)
+	dbCluster := awsrds.NewRDSDBCluster(config.RDSConfig.Region, iamsvc, rdssvc, logger)
+	sqlProvider := sqlengine.NewProviderService(logger)
+
+	SQSServiceBroker := sqsbroker.New(config.SQSConfig, queue, user, logger)
+	RDSServiceBroker := rdsbroker.New(config.RDSConfig, dbInstance, dbCluster, sqlProvider, logger)
 
 	credentials := brokerapi.BrokerCredentials{
 		Username: config.Username,
 		Password: config.Password,
 	}
 
-	brokerAPI := brokerapi.New(serviceBroker, logger, credentials)
-	http.Handle("/", brokerAPI)
+	SQSBrokerAPI := brokerapi.New(SQSServiceBroker, logger, credentials)
+	fmt.Printf("%v", SQSBrokerAPI)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if html.EscapeString(r.URL.Path) == "/v2/catalog" {
 
-	fmt.Println("SQS Service Broker started on port " + port + "...")
+			// TODO: Make this not suck
+
+			sqs := SQSServiceBroker.ServicesAsString()
+			sqs = sqs[:len(sqs)-1]
+
+			rds := RDSServiceBroker.ServicesAsString()
+			rds = rds[1:len(rds)]
+
+			services := fmt.Sprintf("{ \"services\": %v, %v }", sqs, rds)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(services))
+
+		} else {
+			fmt.Println("Parse and route to correct broker")
+		}
+	})
+
+	fmt.Printf("AWS Service Broker started on %q using config %q...\n", port, configFilePath)
 	http.ListenAndServe(":"+port, nil)
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,5 +4,15 @@ applications:
     disk_quota: 256M
     buildpack: go_buildpack
     env:
-      AWS_ACCESS_KEY_ID: "your-aws-access-key-id"
-      AWS_SECRET_ACCESS_KEY: "your-aws-secret-access-key"
+      AUTH_USER: user
+      AUTH_PASS: pass
+      AWS_ACCESS_KEY_ID: "AKIAJPQBDSI4RQMF74IA"
+      AWS_SECRET_ACCESS_KEY: "WC2Zf+sx1+cl7JqoN5SO6d1hSvYMRsjwK0XAIE+e"
+      DB_NAME: broker-test
+      DB_PASS: rds
+      DB_PORT: 5524
+      DB_SSLMODE: verify-ca
+      DB_TYPE: sqlite3
+      DB_URL: 10.244.0.30
+      DB_USER: rds
+      ENC_KEY: "12345678901234567890123456789012"

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -1,0 +1,761 @@
+package rdsbroker
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/frodenas/brokerapi"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pivotal-golang/lager"
+
+	"github.com/cf-platform-eng/sqs-broker/awsrds"
+	"github.com/cf-platform-eng/sqs-broker/sqlengine"
+	"github.com/cf-platform-eng/sqs-broker/utils"
+)
+
+const defaultUsernameLength = 16
+const defaultPasswordLength = 32
+
+const instanceIDLogKey = "instance-id"
+const bindingIDLogKey = "binding-id"
+const detailsLogKey = "details"
+const acceptsIncompleteLogKey = "acceptsIncomplete"
+
+var rdsStatus2State = map[string]string{
+	"available":                    brokerapi.LastOperationSucceeded,
+	"backing-up":                   brokerapi.LastOperationInProgress,
+	"creating":                     brokerapi.LastOperationInProgress,
+	"deleting":                     brokerapi.LastOperationInProgress,
+	"maintenance":                  brokerapi.LastOperationInProgress,
+	"modifying":                    brokerapi.LastOperationInProgress,
+	"rebooting":                    brokerapi.LastOperationInProgress,
+	"renaming":                     brokerapi.LastOperationInProgress,
+	"resetting-master-credentials": brokerapi.LastOperationInProgress,
+	"upgrading":                    brokerapi.LastOperationInProgress,
+}
+
+type RDSBroker struct {
+	dbPrefix                     string
+	allowUserProvisionParameters bool
+	allowUserUpdateParameters    bool
+	allowUserBindParameters      bool
+	catalog                      Catalog
+	dbInstance                   awsrds.DBInstance
+	dbCluster                    awsrds.DBCluster
+	sqlProvider                  sqlengine.Provider
+	logger                       lager.Logger
+}
+
+func New(
+	config Config,
+	dbInstance awsrds.DBInstance,
+	dbCluster awsrds.DBCluster,
+	sqlProvider sqlengine.Provider,
+	logger lager.Logger,
+) *RDSBroker {
+	return &RDSBroker{
+		dbPrefix:                     config.DBPrefix,
+		allowUserProvisionParameters: config.AllowUserProvisionParameters,
+		allowUserUpdateParameters:    config.AllowUserUpdateParameters,
+		allowUserBindParameters:      config.AllowUserBindParameters,
+		catalog:                      config.Catalog,
+		dbInstance:                   dbInstance,
+		dbCluster:                    dbCluster,
+		sqlProvider:                  sqlProvider,
+		logger:                       logger.Session("broker"),
+	}
+}
+
+func (b *RDSBroker) ServicesAsString() string {
+	catalog, err := json.Marshal(b.catalog.Services)
+
+	if err != nil {
+		b.logger.Error("marshal-error", err)
+		return ""
+	}
+
+	return string(catalog)
+}
+
+func (b *RDSBroker) Services() brokerapi.CatalogResponse {
+	catalogResponse := brokerapi.CatalogResponse{}
+
+	brokerCatalog, err := json.Marshal(b.catalog)
+	if err != nil {
+		b.logger.Error("marshal-error", err)
+		return catalogResponse
+	}
+
+	apiCatalog := brokerapi.Catalog{}
+	if err = json.Unmarshal(brokerCatalog, &apiCatalog); err != nil {
+		b.logger.Error("unmarshal-error", err)
+		return catalogResponse
+	}
+
+	catalogResponse.Services = apiCatalog.Services
+
+	return catalogResponse
+}
+
+func (b *RDSBroker) Provision(instanceID string, details brokerapi.ProvisionDetails, acceptsIncomplete bool) (brokerapi.ProvisioningResponse, bool, error) {
+	b.logger.Debug("provision", lager.Data{
+		instanceIDLogKey:        instanceID,
+		detailsLogKey:           details,
+		acceptsIncompleteLogKey: acceptsIncomplete,
+	})
+
+	provisioningResponse := brokerapi.ProvisioningResponse{}
+
+	if !acceptsIncomplete {
+		return provisioningResponse, false, brokerapi.ErrAsyncRequired
+	}
+
+	provisionParameters := ProvisionParameters{}
+	if b.allowUserProvisionParameters {
+		if err := mapstructure.Decode(details.Parameters, &provisionParameters); err != nil {
+			return provisioningResponse, false, err
+		}
+	}
+
+	servicePlan, ok := b.catalog.FindServicePlan(details.PlanID)
+	if !ok {
+		return provisioningResponse, false, fmt.Errorf("Service Plan '%s' not found", details.PlanID)
+	}
+
+	var err error
+	if strings.ToLower(servicePlan.RDSProperties.Engine) == "aurora" {
+		createDBCluster := b.createDBCluster(instanceID, servicePlan, provisionParameters, details)
+		if err = b.dbCluster.Create(b.dbClusterIdentifier(instanceID), *createDBCluster); err != nil {
+			return provisioningResponse, false, err
+		}
+		defer func() {
+			if err != nil {
+				b.dbCluster.Delete(b.dbClusterIdentifier(instanceID), servicePlan.RDSProperties.SkipFinalSnapshot)
+			}
+		}()
+	}
+
+	createDBInstance := b.createDBInstance(instanceID, servicePlan, provisionParameters, details)
+	if err = b.dbInstance.Create(b.dbInstanceIdentifier(instanceID), *createDBInstance); err != nil {
+		return provisioningResponse, false, err
+	}
+
+	return provisioningResponse, true, nil
+}
+
+func (b *RDSBroker) Update(instanceID string, details brokerapi.UpdateDetails, acceptsIncomplete bool) (bool, error) {
+	b.logger.Debug("update", lager.Data{
+		instanceIDLogKey:        instanceID,
+		detailsLogKey:           details,
+		acceptsIncompleteLogKey: acceptsIncomplete,
+	})
+
+	if !acceptsIncomplete {
+		return false, brokerapi.ErrAsyncRequired
+	}
+
+	updateParameters := UpdateParameters{}
+	if b.allowUserUpdateParameters {
+		if err := mapstructure.Decode(details.Parameters, &updateParameters); err != nil {
+			return false, err
+		}
+	}
+
+	service, ok := b.catalog.FindService(details.ServiceID)
+	if !ok {
+		return false, fmt.Errorf("Service '%s' not found", details.ServiceID)
+	}
+
+	if !service.PlanUpdateable {
+		return false, brokerapi.ErrInstanceNotUpdateable
+	}
+
+	servicePlan, ok := b.catalog.FindServicePlan(details.PlanID)
+	if !ok {
+		return false, fmt.Errorf("Service Plan '%s' not found", details.PlanID)
+	}
+
+	if strings.ToLower(servicePlan.RDSProperties.Engine) == "aurora" {
+		modifyDBCluster := b.modifyDBCluster(instanceID, servicePlan, updateParameters, details)
+		if err := b.dbCluster.Modify(b.dbClusterIdentifier(instanceID), *modifyDBCluster, updateParameters.ApplyImmediately); err != nil {
+			return false, err
+		}
+	}
+
+	modifyDBInstance := b.modifyDBInstance(instanceID, servicePlan, updateParameters, details)
+	if err := b.dbInstance.Modify(b.dbInstanceIdentifier(instanceID), *modifyDBInstance, updateParameters.ApplyImmediately); err != nil {
+		if err == awsrds.ErrDBInstanceDoesNotExist {
+			return false, brokerapi.ErrInstanceDoesNotExist
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (b *RDSBroker) Deprovision(instanceID string, details brokerapi.DeprovisionDetails, acceptsIncomplete bool) (bool, error) {
+	b.logger.Debug("deprovision", lager.Data{
+		instanceIDLogKey:        instanceID,
+		detailsLogKey:           details,
+		acceptsIncompleteLogKey: acceptsIncomplete,
+	})
+
+	if !acceptsIncomplete {
+		return false, brokerapi.ErrAsyncRequired
+	}
+
+	servicePlan, ok := b.catalog.FindServicePlan(details.PlanID)
+	if !ok {
+		return false, fmt.Errorf("Service Plan '%s' not found", details.PlanID)
+	}
+
+	skipDBInstanceFinalSnapshot := servicePlan.RDSProperties.SkipFinalSnapshot
+	if strings.ToLower(servicePlan.RDSProperties.Engine) == "aurora" {
+		skipDBInstanceFinalSnapshot = true
+	}
+
+	if err := b.dbInstance.Delete(b.dbInstanceIdentifier(instanceID), skipDBInstanceFinalSnapshot); err != nil {
+		if err == awsrds.ErrDBInstanceDoesNotExist {
+			return false, brokerapi.ErrInstanceDoesNotExist
+		}
+		return false, err
+	}
+
+	if strings.ToLower(servicePlan.RDSProperties.Engine) == "aurora" {
+		b.dbCluster.Delete(b.dbClusterIdentifier(instanceID), servicePlan.RDSProperties.SkipFinalSnapshot)
+	}
+
+	return true, nil
+}
+
+func (b *RDSBroker) Bind(instanceID, bindingID string, details brokerapi.BindDetails) (brokerapi.BindingResponse, error) {
+	b.logger.Debug("bind", lager.Data{
+		instanceIDLogKey: instanceID,
+		bindingIDLogKey:  bindingID,
+		detailsLogKey:    details,
+	})
+
+	bindingResponse := brokerapi.BindingResponse{}
+
+	bindParameters := BindParameters{}
+	if b.allowUserBindParameters {
+		if err := mapstructure.Decode(details.Parameters, &bindParameters); err != nil {
+			return bindingResponse, err
+		}
+	}
+
+	service, ok := b.catalog.FindService(details.ServiceID)
+	if !ok {
+		return bindingResponse, fmt.Errorf("Service '%s' not found", details.ServiceID)
+	}
+
+	if !service.Bindable {
+		return bindingResponse, brokerapi.ErrInstanceNotBindable
+	}
+
+	servicePlan, ok := b.catalog.FindServicePlan(details.PlanID)
+	if !ok {
+		return bindingResponse, fmt.Errorf("Service Plan '%s' not found", details.PlanID)
+	}
+
+	var dbAddress, dbName, masterUsername string
+	var dbPort int64
+	if strings.ToLower(servicePlan.RDSProperties.Engine) == "aurora" {
+		dbClusterDetails, err := b.dbCluster.Describe(b.dbClusterIdentifier(instanceID))
+		if err != nil {
+			if err == awsrds.ErrDBInstanceDoesNotExist {
+				return bindingResponse, brokerapi.ErrInstanceDoesNotExist
+			}
+			return bindingResponse, err
+		}
+
+		dbAddress = dbClusterDetails.Endpoint
+		dbPort = dbClusterDetails.Port
+		masterUsername = dbClusterDetails.MasterUsername
+		if dbClusterDetails.DatabaseName != "" {
+			dbName = dbClusterDetails.DatabaseName
+		} else {
+			dbName = b.dbName(instanceID)
+		}
+	} else {
+		dbInstanceDetails, err := b.dbInstance.Describe(b.dbInstanceIdentifier(instanceID))
+		if err != nil {
+			if err == awsrds.ErrDBInstanceDoesNotExist {
+				return bindingResponse, brokerapi.ErrInstanceDoesNotExist
+			}
+			return bindingResponse, err
+		}
+
+		dbAddress = dbInstanceDetails.Address
+		dbPort = dbInstanceDetails.Port
+		masterUsername = dbInstanceDetails.MasterUsername
+		if dbInstanceDetails.DBName != "" {
+			dbName = dbInstanceDetails.DBName
+		} else {
+			dbName = b.dbName(instanceID)
+		}
+	}
+
+	sqlEngine, err := b.sqlProvider.GetSQLEngine(servicePlan.RDSProperties.Engine)
+	if err != nil {
+		return bindingResponse, err
+	}
+
+	if err = sqlEngine.Open(dbAddress, dbPort, dbName, masterUsername, b.masterPassword(instanceID)); err != nil {
+		return bindingResponse, err
+	}
+	defer sqlEngine.Close()
+
+	dbUsername := b.dbUsername(bindingID)
+	dbPassword := b.dbPassword()
+
+	if bindParameters.DBName != "" {
+		dbName = bindParameters.DBName
+		if err = sqlEngine.CreateDB(dbName); err != nil {
+			return bindingResponse, err
+		}
+	}
+
+	if err = sqlEngine.CreateUser(dbUsername, dbPassword); err != nil {
+		return bindingResponse, err
+	}
+
+	if err = sqlEngine.GrantPrivileges(dbName, dbUsername); err != nil {
+		return bindingResponse, err
+	}
+
+	bindingResponse.Credentials = &brokerapi.CredentialsHash{
+		Host:     dbAddress,
+		Port:     dbPort,
+		Name:     dbName,
+		Username: dbUsername,
+		Password: dbPassword,
+		URI:      sqlEngine.URI(dbAddress, dbPort, dbName, dbUsername, dbPassword),
+		JDBCURI:  sqlEngine.JDBCURI(dbAddress, dbPort, dbName, dbUsername, dbPassword),
+	}
+
+	return bindingResponse, nil
+}
+
+func (b *RDSBroker) Unbind(instanceID, bindingID string, details brokerapi.UnbindDetails) error {
+	b.logger.Debug("unbind", lager.Data{
+		instanceIDLogKey: instanceID,
+		bindingIDLogKey:  bindingID,
+		detailsLogKey:    details,
+	})
+
+	servicePlan, ok := b.catalog.FindServicePlan(details.PlanID)
+	if !ok {
+		return fmt.Errorf("Service Plan '%s' not found", details.PlanID)
+	}
+
+	var dbAddress, dbName, masterUsername string
+	var dbPort int64
+	if strings.ToLower(servicePlan.RDSProperties.Engine) == "aurora" {
+		dbClusterDetails, err := b.dbCluster.Describe(b.dbClusterIdentifier(instanceID))
+		if err != nil {
+			if err == awsrds.ErrDBInstanceDoesNotExist {
+				return brokerapi.ErrInstanceDoesNotExist
+			}
+			return err
+		}
+
+		dbAddress = dbClusterDetails.Endpoint
+		dbPort = dbClusterDetails.Port
+		masterUsername = dbClusterDetails.MasterUsername
+		if dbClusterDetails.DatabaseName != "" {
+			dbName = dbClusterDetails.DatabaseName
+		} else {
+			dbName = b.dbName(instanceID)
+		}
+	} else {
+		dbInstanceDetails, err := b.dbInstance.Describe(b.dbInstanceIdentifier(instanceID))
+		if err != nil {
+			if err == awsrds.ErrDBInstanceDoesNotExist {
+				return brokerapi.ErrInstanceDoesNotExist
+			}
+			return err
+		}
+
+		dbAddress = dbInstanceDetails.Address
+		dbPort = dbInstanceDetails.Port
+		masterUsername = dbInstanceDetails.MasterUsername
+		if dbInstanceDetails.DBName != "" {
+			dbName = dbInstanceDetails.DBName
+		} else {
+			dbName = b.dbName(instanceID)
+		}
+	}
+
+	sqlEngine, err := b.sqlProvider.GetSQLEngine(servicePlan.RDSProperties.Engine)
+	if err != nil {
+		return err
+	}
+
+	if err = sqlEngine.Open(dbAddress, dbPort, dbName, masterUsername, b.masterPassword(instanceID)); err != nil {
+		return err
+	}
+	defer sqlEngine.Close()
+
+	privileges, err := sqlEngine.Privileges()
+	if err != nil {
+		return err
+	}
+
+	var userDB string
+	dbUsername := b.dbUsername(bindingID)
+	for privDBName, userNames := range privileges {
+		for _, userName := range userNames {
+			if userName == dbUsername {
+				userDB = privDBName
+				break
+			}
+		}
+	}
+
+	if userDB != "" {
+		if err = sqlEngine.RevokePrivileges(userDB, dbUsername); err != nil {
+			return err
+		}
+
+		if userDB != dbName {
+			users := privileges[userDB]
+			if len(users) == 1 {
+				if err = sqlEngine.DropDB(userDB); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if err = sqlEngine.DropUser(dbUsername); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *RDSBroker) LastOperation(instanceID string) (brokerapi.LastOperationResponse, error) {
+	b.logger.Debug("last-operation", lager.Data{
+		instanceIDLogKey: instanceID,
+	})
+
+	lastOperationResponse := brokerapi.LastOperationResponse{State: brokerapi.LastOperationFailed}
+
+	dbInstanceDetails, err := b.dbInstance.Describe(b.dbInstanceIdentifier(instanceID))
+	if err != nil {
+		if err == awsrds.ErrDBInstanceDoesNotExist {
+			return lastOperationResponse, brokerapi.ErrInstanceDoesNotExist
+		}
+		return lastOperationResponse, err
+	}
+
+	lastOperationResponse.Description = fmt.Sprintf("DB Instance '%s' status is '%s'", b.dbInstanceIdentifier(instanceID), dbInstanceDetails.Status)
+
+	if state, ok := rdsStatus2State[dbInstanceDetails.Status]; ok {
+		lastOperationResponse.State = state
+	}
+
+	if lastOperationResponse.State == brokerapi.LastOperationSucceeded && dbInstanceDetails.PendingModifications {
+		lastOperationResponse.State = brokerapi.LastOperationInProgress
+		lastOperationResponse.Description = fmt.Sprintf("DB Instance '%s' has pending modifications", b.dbInstanceIdentifier(instanceID))
+	}
+
+	return lastOperationResponse, nil
+}
+
+func (b *RDSBroker) dbClusterIdentifier(instanceID string) string {
+	return fmt.Sprintf("%s-%s", b.dbPrefix, strings.Replace(instanceID, "_", "-", -1))
+}
+
+func (b *RDSBroker) dbInstanceIdentifier(instanceID string) string {
+	return fmt.Sprintf("%s-%s", b.dbPrefix, strings.Replace(instanceID, "_", "-", -1))
+}
+
+func (b *RDSBroker) masterUsername() string {
+	return utils.RandomAlphaNum(defaultUsernameLength)
+}
+
+func (b *RDSBroker) masterPassword(instanceID string) string {
+	return utils.GetMD5B64(instanceID, defaultPasswordLength)
+}
+
+func (b *RDSBroker) dbUsername(bindingID string) string {
+	return utils.GetMD5B64(bindingID, defaultUsernameLength)
+}
+
+func (b *RDSBroker) dbPassword() string {
+	return utils.RandomAlphaNum(defaultPasswordLength)
+}
+
+func (b *RDSBroker) dbName(instanceID string) string {
+	return fmt.Sprintf("%s_%s", b.dbPrefix, strings.Replace(instanceID, "-", "_", -1))
+}
+
+func (b *RDSBroker) createDBCluster(instanceID string, servicePlan ServicePlan, provisionParameters ProvisionParameters, details brokerapi.ProvisionDetails) *awsrds.DBClusterDetails {
+	dbClusterDetails := b.dbClusterFromPlan(servicePlan)
+	dbClusterDetails.DatabaseName = b.dbName(instanceID)
+	dbClusterDetails.MasterUsername = b.masterUsername()
+	dbClusterDetails.MasterUserPassword = b.masterPassword(instanceID)
+
+	if provisionParameters.BackupRetentionPeriod > 0 {
+		dbClusterDetails.BackupRetentionPeriod = provisionParameters.BackupRetentionPeriod
+	}
+
+	if provisionParameters.DBName != "" {
+		dbClusterDetails.DatabaseName = provisionParameters.DBName
+	}
+
+	if provisionParameters.PreferredBackupWindow != "" {
+		dbClusterDetails.PreferredBackupWindow = provisionParameters.PreferredBackupWindow
+	}
+
+	if provisionParameters.PreferredMaintenanceWindow != "" {
+		dbClusterDetails.PreferredMaintenanceWindow = provisionParameters.PreferredMaintenanceWindow
+	}
+
+	dbClusterDetails.Tags = b.dbTags("Created", details.ServiceID, details.PlanID, details.OrganizationGUID, details.SpaceGUID)
+
+	return dbClusterDetails
+}
+
+func (b *RDSBroker) modifyDBCluster(instanceID string, servicePlan ServicePlan, updateParameters UpdateParameters, details brokerapi.UpdateDetails) *awsrds.DBClusterDetails {
+	dbClusterDetails := b.dbClusterFromPlan(servicePlan)
+
+	if updateParameters.BackupRetentionPeriod > 0 {
+		dbClusterDetails.BackupRetentionPeriod = updateParameters.BackupRetentionPeriod
+	}
+
+	if updateParameters.PreferredBackupWindow != "" {
+		dbClusterDetails.PreferredBackupWindow = updateParameters.PreferredBackupWindow
+	}
+
+	if updateParameters.PreferredMaintenanceWindow != "" {
+		dbClusterDetails.PreferredMaintenanceWindow = updateParameters.PreferredMaintenanceWindow
+	}
+
+	dbClusterDetails.Tags = b.dbTags("Updated", details.ServiceID, details.PlanID, "", "")
+
+	return dbClusterDetails
+}
+
+func (b *RDSBroker) dbClusterFromPlan(servicePlan ServicePlan) *awsrds.DBClusterDetails {
+	dbClusterDetails := &awsrds.DBClusterDetails{
+		Engine: servicePlan.RDSProperties.Engine,
+	}
+
+	if servicePlan.RDSProperties.AvailabilityZone != "" {
+		dbClusterDetails.AvailabilityZones = []string{servicePlan.RDSProperties.AvailabilityZone}
+	}
+
+	if servicePlan.RDSProperties.BackupRetentionPeriod > 0 {
+		dbClusterDetails.BackupRetentionPeriod = servicePlan.RDSProperties.BackupRetentionPeriod
+	}
+
+	if servicePlan.RDSProperties.DBClusterParameterGroupName != "" {
+		dbClusterDetails.DBClusterParameterGroupName = servicePlan.RDSProperties.DBClusterParameterGroupName
+	}
+
+	if servicePlan.RDSProperties.DBSubnetGroupName != "" {
+		dbClusterDetails.DBSubnetGroupName = servicePlan.RDSProperties.DBSubnetGroupName
+	}
+
+	if servicePlan.RDSProperties.EngineVersion != "" {
+		dbClusterDetails.EngineVersion = servicePlan.RDSProperties.EngineVersion
+	}
+
+	if servicePlan.RDSProperties.Port > 0 {
+		dbClusterDetails.Port = servicePlan.RDSProperties.Port
+	}
+
+	if servicePlan.RDSProperties.PreferredBackupWindow != "" {
+		dbClusterDetails.PreferredBackupWindow = servicePlan.RDSProperties.PreferredBackupWindow
+	}
+
+	if servicePlan.RDSProperties.PreferredMaintenanceWindow != "" {
+		dbClusterDetails.PreferredMaintenanceWindow = servicePlan.RDSProperties.PreferredMaintenanceWindow
+	}
+
+	if len(servicePlan.RDSProperties.VpcSecurityGroupIds) > 0 {
+		dbClusterDetails.VpcSecurityGroupIds = servicePlan.RDSProperties.VpcSecurityGroupIds
+	}
+
+	return dbClusterDetails
+}
+
+func (b *RDSBroker) createDBInstance(instanceID string, servicePlan ServicePlan, provisionParameters ProvisionParameters, details brokerapi.ProvisionDetails) *awsrds.DBInstanceDetails {
+	dbInstanceDetails := b.dbInstanceFromPlan(servicePlan)
+
+	if strings.ToLower(servicePlan.RDSProperties.Engine) == "aurora" {
+		dbInstanceDetails.DBClusterIdentifier = b.dbClusterIdentifier(instanceID)
+	} else {
+		dbInstanceDetails.DBName = b.dbName(instanceID)
+		dbInstanceDetails.MasterUsername = b.masterUsername()
+		dbInstanceDetails.MasterUserPassword = b.masterPassword(instanceID)
+
+		if provisionParameters.BackupRetentionPeriod > 0 {
+			dbInstanceDetails.BackupRetentionPeriod = provisionParameters.BackupRetentionPeriod
+		}
+
+		if provisionParameters.CharacterSetName != "" {
+			dbInstanceDetails.CharacterSetName = provisionParameters.CharacterSetName
+		}
+
+		if provisionParameters.DBName != "" {
+			dbInstanceDetails.DBName = provisionParameters.DBName
+		}
+
+		if provisionParameters.PreferredBackupWindow != "" {
+			dbInstanceDetails.PreferredBackupWindow = provisionParameters.PreferredBackupWindow
+		}
+	}
+
+	if provisionParameters.PreferredMaintenanceWindow != "" {
+		dbInstanceDetails.PreferredMaintenanceWindow = provisionParameters.PreferredMaintenanceWindow
+	}
+
+	dbInstanceDetails.Tags = b.dbTags("Created", details.ServiceID, details.PlanID, details.OrganizationGUID, details.SpaceGUID)
+
+	return dbInstanceDetails
+}
+
+func (b *RDSBroker) modifyDBInstance(instanceID string, servicePlan ServicePlan, updateParameters UpdateParameters, details brokerapi.UpdateDetails) *awsrds.DBInstanceDetails {
+	dbInstanceDetails := b.dbInstanceFromPlan(servicePlan)
+
+	if strings.ToLower(servicePlan.RDSProperties.Engine) != "aurora" {
+		if updateParameters.BackupRetentionPeriod > 0 {
+			dbInstanceDetails.BackupRetentionPeriod = updateParameters.BackupRetentionPeriod
+		}
+
+		if updateParameters.PreferredBackupWindow != "" {
+			dbInstanceDetails.PreferredBackupWindow = updateParameters.PreferredBackupWindow
+		}
+	}
+
+	if updateParameters.PreferredMaintenanceWindow != "" {
+		dbInstanceDetails.PreferredMaintenanceWindow = updateParameters.PreferredMaintenanceWindow
+	}
+
+	dbInstanceDetails.Tags = b.dbTags("Updated", details.ServiceID, details.PlanID, "", "")
+
+	return dbInstanceDetails
+}
+
+func (b *RDSBroker) dbInstanceFromPlan(servicePlan ServicePlan) *awsrds.DBInstanceDetails {
+	dbInstanceDetails := &awsrds.DBInstanceDetails{
+		DBInstanceClass: servicePlan.RDSProperties.DBInstanceClass,
+		Engine:          servicePlan.RDSProperties.Engine,
+	}
+
+	dbInstanceDetails.AutoMinorVersionUpgrade = servicePlan.RDSProperties.AutoMinorVersionUpgrade
+
+	if servicePlan.RDSProperties.AvailabilityZone != "" {
+		dbInstanceDetails.AvailabilityZone = servicePlan.RDSProperties.AvailabilityZone
+	}
+
+	dbInstanceDetails.CopyTagsToSnapshot = servicePlan.RDSProperties.CopyTagsToSnapshot
+
+	if servicePlan.RDSProperties.DBParameterGroupName != "" {
+		dbInstanceDetails.DBParameterGroupName = servicePlan.RDSProperties.DBParameterGroupName
+	}
+
+	if servicePlan.RDSProperties.DBSubnetGroupName != "" {
+		dbInstanceDetails.DBSubnetGroupName = servicePlan.RDSProperties.DBSubnetGroupName
+	}
+
+	if servicePlan.RDSProperties.EngineVersion != "" {
+		dbInstanceDetails.EngineVersion = servicePlan.RDSProperties.EngineVersion
+	}
+
+	if servicePlan.RDSProperties.OptionGroupName != "" {
+		dbInstanceDetails.OptionGroupName = servicePlan.RDSProperties.OptionGroupName
+	}
+
+	if servicePlan.RDSProperties.PreferredMaintenanceWindow != "" {
+		dbInstanceDetails.PreferredMaintenanceWindow = servicePlan.RDSProperties.PreferredMaintenanceWindow
+	}
+
+	dbInstanceDetails.PubliclyAccessible = servicePlan.RDSProperties.PubliclyAccessible
+
+	if strings.ToLower(servicePlan.RDSProperties.Engine) != "aurora" {
+		if servicePlan.RDSProperties.AllocatedStorage > 0 {
+			dbInstanceDetails.AllocatedStorage = servicePlan.RDSProperties.AllocatedStorage
+		}
+
+		if servicePlan.RDSProperties.BackupRetentionPeriod > 0 {
+			dbInstanceDetails.BackupRetentionPeriod = servicePlan.RDSProperties.BackupRetentionPeriod
+		}
+
+		if servicePlan.RDSProperties.CharacterSetName != "" {
+			dbInstanceDetails.CharacterSetName = servicePlan.RDSProperties.CharacterSetName
+		}
+
+		if len(servicePlan.RDSProperties.DBSecurityGroups) > 0 {
+			dbInstanceDetails.DBSecurityGroups = servicePlan.RDSProperties.DBSecurityGroups
+		}
+
+		if servicePlan.RDSProperties.Iops > 0 {
+			dbInstanceDetails.Iops = servicePlan.RDSProperties.Iops
+		}
+
+		if servicePlan.RDSProperties.KmsKeyID != "" {
+			dbInstanceDetails.KmsKeyID = servicePlan.RDSProperties.KmsKeyID
+		}
+
+		if servicePlan.RDSProperties.LicenseModel != "" {
+			dbInstanceDetails.LicenseModel = servicePlan.RDSProperties.LicenseModel
+		}
+
+		dbInstanceDetails.MultiAZ = servicePlan.RDSProperties.MultiAZ
+
+		if servicePlan.RDSProperties.Port > 0 {
+			dbInstanceDetails.Port = servicePlan.RDSProperties.Port
+		}
+
+		if servicePlan.RDSProperties.PreferredBackupWindow != "" {
+			dbInstanceDetails.PreferredBackupWindow = servicePlan.RDSProperties.PreferredBackupWindow
+		}
+
+		dbInstanceDetails.StorageEncrypted = servicePlan.RDSProperties.StorageEncrypted
+
+		if servicePlan.RDSProperties.StorageType != "" {
+			dbInstanceDetails.StorageType = servicePlan.RDSProperties.StorageType
+		}
+
+		if len(servicePlan.RDSProperties.VpcSecurityGroupIds) > 0 {
+			dbInstanceDetails.VpcSecurityGroupIds = servicePlan.RDSProperties.VpcSecurityGroupIds
+		}
+	}
+
+	return dbInstanceDetails
+}
+
+func (b *RDSBroker) dbTags(action, serviceID, planID, organizationID, spaceID string) map[string]string {
+	tags := make(map[string]string)
+
+	tags["Owner"] = "Cloud Foundry"
+
+	tags[action+" by"] = "AWS RDS Service Broker"
+
+	tags[action+" at"] = time.Now().Format(time.RFC822Z)
+
+	if serviceID != "" {
+		tags["Service ID"] = serviceID
+	}
+
+	if planID != "" {
+		tags["Plan ID"] = planID
+	}
+
+	if organizationID != "" {
+		tags["Organization ID"] = organizationID
+	}
+
+	if spaceID != "" {
+		tags["Space ID"] = spaceID
+	}
+
+	return tags
+}

--- a/rdsbroker/broker_suite_test.go
+++ b/rdsbroker/broker_suite_test.go
@@ -1,0 +1,13 @@
+package rdsbroker_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRDSBroker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RDS Broker Suite")
+}

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -1,0 +1,2413 @@
+package rdsbroker_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/rdsbroker"
+
+	"github.com/frodenas/brokerapi"
+	"github.com/pivotal-golang/lager"
+	"github.com/pivotal-golang/lager/lagertest"
+
+	"github.com/cf-platform-eng/sqs-broker/awsrds"
+	rdsfake "github.com/cf-platform-eng/sqs-broker/awsrds/fakes"
+	sqlfake "github.com/cf-platform-eng/sqs-broker/sqlengine/fakes"
+)
+
+var _ = Describe("RDS Broker", func() {
+	var (
+		rdsProperties1 RDSProperties
+		rdsProperties2 RDSProperties
+		plan1          ServicePlan
+		plan2          ServicePlan
+		service1       Service
+		service2       Service
+		catalog        Catalog
+
+		config Config
+
+		dbInstance *rdsfake.FakeDBInstance
+		dbCluster  *rdsfake.FakeDBCluster
+
+		sqlProvider *sqlfake.FakeProvider
+		sqlEngine   *sqlfake.FakeSQLEngine
+
+		testSink *lagertest.TestSink
+		logger   lager.Logger
+
+		rdsBroker *RDSBroker
+
+		allowUserProvisionParameters bool
+		allowUserUpdateParameters    bool
+		allowUserBindParameters      bool
+		serviceBindable              bool
+		planUpdateable               bool
+		skipFinalSnapshot            bool
+
+		instanceID           = "instance-id"
+		bindingID            = "binding-id"
+		dbInstanceIdentifier = "cf-instance-id"
+		dbClusterIdentifier  = "cf-instance-id"
+		dbName               = "cf_instance_id"
+		dbUsername           = "YmluZGluZy1pZNQd"
+		masterUserPassword   = "aW5zdGFuY2UtaWTUHYzZjwCyBOm"
+	)
+
+	BeforeEach(func() {
+		allowUserProvisionParameters = true
+		allowUserUpdateParameters = true
+		allowUserBindParameters = true
+		serviceBindable = true
+		planUpdateable = true
+		skipFinalSnapshot = true
+
+		dbInstance = &rdsfake.FakeDBInstance{}
+		dbCluster = &rdsfake.FakeDBCluster{}
+
+		sqlProvider = &sqlfake.FakeProvider{}
+		sqlEngine = &sqlfake.FakeSQLEngine{}
+		sqlProvider.GetSQLEngineSQLEngine = sqlEngine
+
+		rdsProperties1 = RDSProperties{
+			DBInstanceClass:   "db.m1.test",
+			Engine:            "test-engine-1",
+			EngineVersion:     "1.2.3",
+			AllocatedStorage:  100,
+			SkipFinalSnapshot: skipFinalSnapshot,
+		}
+
+		rdsProperties2 = RDSProperties{
+			DBInstanceClass:   "db.m2.test",
+			Engine:            "test-engine-2",
+			EngineVersion:     "4.5.6",
+			AllocatedStorage:  200,
+			SkipFinalSnapshot: skipFinalSnapshot,
+		}
+	})
+
+	JustBeforeEach(func() {
+		plan1 = ServicePlan{
+			ID:            "Plan-1",
+			Name:          "Plan 1",
+			Description:   "This is the Plan 1",
+			RDSProperties: rdsProperties1,
+		}
+		plan2 = ServicePlan{
+			ID:            "Plan-2",
+			Name:          "Plan 2",
+			Description:   "This is the Plan 2",
+			RDSProperties: rdsProperties2,
+		}
+
+		service1 = Service{
+			ID:             "Service-1",
+			Name:           "Service 1",
+			Description:    "This is the Service 1",
+			Bindable:       serviceBindable,
+			PlanUpdateable: planUpdateable,
+			Plans:          []ServicePlan{plan1},
+		}
+		service2 = Service{
+			ID:             "Service-2",
+			Name:           "Service 2",
+			Description:    "This is the Service 2",
+			Bindable:       serviceBindable,
+			PlanUpdateable: planUpdateable,
+			Plans:          []ServicePlan{plan2},
+		}
+
+		catalog = Catalog{
+			Services: []Service{service1, service2},
+		}
+
+		config = Config{
+			Region:                       "rds-region",
+			DBPrefix:                     "cf",
+			AllowUserProvisionParameters: allowUserProvisionParameters,
+			AllowUserUpdateParameters:    allowUserUpdateParameters,
+			AllowUserBindParameters:      allowUserBindParameters,
+			Catalog:                      catalog,
+		}
+
+		logger = lager.NewLogger("rdsbroker_test")
+		testSink = lagertest.NewTestSink()
+		logger.RegisterSink(testSink)
+
+		rdsBroker = New(config, dbInstance, dbCluster, sqlProvider, logger)
+	})
+
+	var _ = Describe("Services", func() {
+		var (
+			properCatalogResponse brokerapi.CatalogResponse
+		)
+
+		BeforeEach(func() {
+			properCatalogResponse = brokerapi.CatalogResponse{
+				Services: []brokerapi.Service{
+					brokerapi.Service{
+						ID:             "Service-1",
+						Name:           "Service 1",
+						Description:    "This is the Service 1",
+						Bindable:       serviceBindable,
+						PlanUpdateable: planUpdateable,
+						Plans: []brokerapi.ServicePlan{
+							brokerapi.ServicePlan{
+								ID:          "Plan-1",
+								Name:        "Plan 1",
+								Description: "This is the Plan 1",
+							},
+						},
+					},
+					brokerapi.Service{
+						ID:             "Service-2",
+						Name:           "Service 2",
+						Description:    "This is the Service 2",
+						Bindable:       serviceBindable,
+						PlanUpdateable: planUpdateable,
+						Plans: []brokerapi.ServicePlan{
+							brokerapi.ServicePlan{
+								ID:          "Plan-2",
+								Name:        "Plan 2",
+								Description: "This is the Plan 2",
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("returns the proper CatalogResponse", func() {
+			brokerCatalog := rdsBroker.Services()
+			Expect(brokerCatalog).To(Equal(properCatalogResponse))
+		})
+
+	})
+
+	var _ = Describe("Provision", func() {
+		var (
+			provisionDetails  brokerapi.ProvisionDetails
+			acceptsIncomplete bool
+
+			properProvisioningResponse brokerapi.ProvisioningResponse
+		)
+
+		BeforeEach(func() {
+			provisionDetails = brokerapi.ProvisionDetails{
+				OrganizationGUID: "organization-id",
+				PlanID:           "Plan-1",
+				ServiceID:        "Service-1",
+				SpaceGUID:        "space-id",
+				Parameters:       map[string]interface{}{},
+			}
+			acceptsIncomplete = true
+
+			properProvisioningResponse = brokerapi.ProvisioningResponse{}
+		})
+
+		It("returns the proper response", func() {
+			provisioningResponse, asynch, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+			Expect(provisioningResponse).To(Equal(properProvisioningResponse))
+			Expect(asynch).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("makes the proper calls", func() {
+			_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+			Expect(dbInstance.CreateCalled).To(BeTrue())
+			Expect(dbInstance.CreateID).To(Equal(dbInstanceIdentifier))
+			Expect(dbInstance.CreateDBInstanceDetails.DBInstanceClass).To(Equal("db.m1.test"))
+			Expect(dbInstance.CreateDBInstanceDetails.Engine).To(Equal("test-engine-1"))
+			Expect(dbInstance.CreateDBInstanceDetails.DBName).To(Equal(dbName))
+			Expect(dbInstance.CreateDBInstanceDetails.MasterUsername).ToNot(BeEmpty())
+			Expect(dbInstance.CreateDBInstanceDetails.MasterUserPassword).To(Equal(masterUserPassword))
+			Expect(dbInstance.CreateDBInstanceDetails.Tags["Owner"]).To(Equal("Cloud Foundry"))
+			Expect(dbInstance.CreateDBInstanceDetails.Tags["Created by"]).To(Equal("AWS RDS Service Broker"))
+			Expect(dbInstance.CreateDBInstanceDetails.Tags).To(HaveKey("Created at"))
+			Expect(dbInstance.CreateDBInstanceDetails.Tags["Service ID"]).To(Equal("Service-1"))
+			Expect(dbInstance.CreateDBInstanceDetails.Tags["Plan ID"]).To(Equal("Plan-1"))
+			Expect(dbInstance.CreateDBInstanceDetails.Tags["Organization ID"]).To(Equal("organization-id"))
+			Expect(dbInstance.CreateDBInstanceDetails.Tags["Space ID"]).To(Equal("space-id"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when has AllocatedStorage", func() {
+			BeforeEach(func() {
+				rdsProperties1.AllocatedStorage = int64(100)
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.AllocatedStorage).To(Equal(int64(100)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.AllocatedStorage).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has AutoMinorVersionUpgrade", func() {
+			BeforeEach(func() {
+				rdsProperties1.AutoMinorVersionUpgrade = true
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.AutoMinorVersionUpgrade).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has AvailabilityZone", func() {
+			BeforeEach(func() {
+				rdsProperties1.AvailabilityZone = "test-az"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.AvailabilityZone).To(Equal("test-az"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.AvailabilityZone).To(Equal("test-az"))
+					Expect(dbCluster.CreateDBClusterDetails.AvailabilityZones).To(Equal([]string{"test-az"}))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has BackupRetentionPeriod", func() {
+			BeforeEach(func() {
+				rdsProperties1.BackupRetentionPeriod = int64(7)
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(7)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.BackupRetentionPeriod).To(Equal(int64(7)))
+					Expect(dbInstance.CreateDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("but has BackupRetentionPeriod Parameter", func() {
+				BeforeEach(func() {
+					provisionDetails.Parameters = map[string]interface{}{"backup_retention_period": 12}
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(12)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when Engine is Aurora", func() {
+					BeforeEach(func() {
+						rdsProperties1.Engine = "aurora"
+					})
+
+					It("makes the proper calls", func() {
+						_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+						Expect(dbCluster.CreateDBClusterDetails.BackupRetentionPeriod).To(Equal(int64(12)))
+						Expect(dbInstance.CreateDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(0)))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when has CharacterSetName", func() {
+			BeforeEach(func() {
+				rdsProperties1.CharacterSetName = "test-characterset-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.CharacterSetName).To(Equal("test-characterset-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.CharacterSetName).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("but has CharacterSetName Parameter", func() {
+				BeforeEach(func() {
+					provisionDetails.Parameters = map[string]interface{}{"character_set_name": "test-characterset-name-parameter"}
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.CharacterSetName).To(Equal("test-characterset-name-parameter"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when Engine is Aurora", func() {
+					BeforeEach(func() {
+						rdsProperties1.Engine = "aurora"
+					})
+
+					It("makes the proper calls", func() {
+						_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+						Expect(dbInstance.CreateDBInstanceDetails.CharacterSetName).To(Equal(""))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when has CopyTagsToSnapshot", func() {
+			BeforeEach(func() {
+				rdsProperties1.CopyTagsToSnapshot = true
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.CopyTagsToSnapshot).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBName parameter", func() {
+			BeforeEach(func() {
+				provisionDetails.Parameters = map[string]interface{}{"dbname": "test-dbname"}
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.DBName).To(Equal("test-dbname"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.DatabaseName).To(Equal("test-dbname"))
+					Expect(dbInstance.CreateDBInstanceDetails.DBName).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has DBParameterGroupName", func() {
+			BeforeEach(func() {
+				rdsProperties1.DBParameterGroupName = "test-db-parameter-group-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.DBParameterGroupName).To(Equal("test-db-parameter-group-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBSecurityGroups", func() {
+			BeforeEach(func() {
+				rdsProperties1.DBSecurityGroups = []string{"test-db-security-group"}
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.DBSecurityGroups).To(Equal([]string{"test-db-security-group"}))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.DBSecurityGroups).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has DBSubnetGroupName", func() {
+			BeforeEach(func() {
+				rdsProperties1.DBSubnetGroupName = "test-db-subnet-group-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.DBSubnetGroupName).To(Equal("test-db-subnet-group-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.DBSubnetGroupName).To(Equal("test-db-subnet-group-name"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has EngineVersion", func() {
+			BeforeEach(func() {
+				rdsProperties1.EngineVersion = "1.2.3"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.EngineVersion).To(Equal("1.2.3"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.EngineVersion).To(Equal("1.2.3"))
+					Expect(dbCluster.CreateDBClusterDetails.EngineVersion).To(Equal("1.2.3"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has Iops", func() {
+			BeforeEach(func() {
+				rdsProperties1.Iops = int64(1000)
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.Iops).To(Equal(int64(1000)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.Iops).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has KmsKeyID", func() {
+			BeforeEach(func() {
+				rdsProperties1.KmsKeyID = "test-kms-key-id"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.KmsKeyID).To(Equal("test-kms-key-id"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.KmsKeyID).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has LicenseModel", func() {
+			BeforeEach(func() {
+				rdsProperties1.LicenseModel = "test-license-model"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.LicenseModel).To(Equal("test-license-model"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.LicenseModel).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has MultiAZ", func() {
+			BeforeEach(func() {
+				rdsProperties1.MultiAZ = true
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.MultiAZ).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.MultiAZ).To(BeFalse())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has OptionGroupName", func() {
+			BeforeEach(func() {
+				rdsProperties1.OptionGroupName = "test-option-group-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.OptionGroupName).To(Equal("test-option-group-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Port", func() {
+			BeforeEach(func() {
+				rdsProperties1.Port = int64(3306)
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.Port).To(Equal(int64(3306)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.Port).To(Equal(int64(3306)))
+					Expect(dbInstance.CreateDBInstanceDetails.Port).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has PreferredBackupWindow", func() {
+			BeforeEach(func() {
+				rdsProperties1.PreferredBackupWindow = "test-preferred-backup-window"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window"))
+					Expect(dbInstance.CreateDBInstanceDetails.PreferredBackupWindow).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("but has PreferredBackupWindow Parameter", func() {
+				BeforeEach(func() {
+					provisionDetails.Parameters = map[string]interface{}{"preferred_backup_window": "test-preferred-backup-window-parameter"}
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window-parameter"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when Engine is Aurora", func() {
+					BeforeEach(func() {
+						rdsProperties1.Engine = "aurora"
+					})
+
+					It("makes the proper calls", func() {
+						_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+						Expect(dbCluster.CreateDBClusterDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window-parameter"))
+						Expect(dbInstance.CreateDBInstanceDetails.PreferredBackupWindow).To(Equal(""))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when has PreferredMaintenanceWindow", func() {
+			BeforeEach(func() {
+				rdsProperties1.PreferredMaintenanceWindow = "test-preferred-maintenance-window"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("but has PreferredMaintenanceWindow Parameter", func() {
+				BeforeEach(func() {
+					provisionDetails.Parameters = map[string]interface{}{"preferred_maintenance_window": "test-preferred-maintenance-window-parameter"}
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window-parameter"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when Engine is Aurora", func() {
+					BeforeEach(func() {
+						rdsProperties1.Engine = "aurora"
+					})
+
+					It("makes the proper calls", func() {
+						_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+						Expect(dbCluster.CreateDBClusterDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window-parameter"))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when has PubliclyAccessible", func() {
+			BeforeEach(func() {
+				rdsProperties1.PubliclyAccessible = true
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.PubliclyAccessible).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has StorageEncrypted", func() {
+			BeforeEach(func() {
+				rdsProperties1.StorageEncrypted = true
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.StorageEncrypted).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.StorageEncrypted).To(BeFalse())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has StorageType", func() {
+			BeforeEach(func() {
+				rdsProperties1.StorageType = "test-storage-type"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.StorageType).To(Equal("test-storage-type"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbInstance.CreateDBInstanceDetails.StorageType).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has VpcSecurityGroupIds", func() {
+			BeforeEach(func() {
+				rdsProperties1.VpcSecurityGroupIds = []string{"test-vpc-security-group-ids"}
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.VpcSecurityGroupIds).To(Equal([]string{"test-vpc-security-group-ids"}))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.VpcSecurityGroupIds).To(Equal([]string{"test-vpc-security-group-ids"}))
+					Expect(dbInstance.CreateDBInstanceDetails.VpcSecurityGroupIds).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when request does not accept incomplete", func() {
+			BeforeEach(func() {
+				acceptsIncomplete = false
+			})
+
+			It("returns the proper error", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(brokerapi.ErrAsyncRequired))
+			})
+		})
+
+		Context("when Parameters are not valid", func() {
+			BeforeEach(func() {
+				provisionDetails.Parameters = map[string]interface{}{"backup_retention_period": "invalid"}
+			})
+
+			It("returns the proper error", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("'backup_retention_period' expected type 'int64', got unconvertible type 'string'"))
+			})
+
+			Context("and user provision parameters are not allowed", func() {
+				BeforeEach(func() {
+					allowUserProvisionParameters = false
+				})
+
+				It("does not return an error", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when Service Plan is not found", func() {
+			BeforeEach(func() {
+				provisionDetails.PlanID = "unknown"
+			})
+
+			It("returns the proper error", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Service Plan 'unknown' not found"))
+			})
+		})
+
+		Context("when creating the DB Instance fails", func() {
+			BeforeEach(func() {
+				dbInstance.CreateError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+		})
+
+		Context("when Engine is Aurora", func() {
+			BeforeEach(func() {
+				rdsProperties1.Engine = "aurora"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbCluster.CreateCalled).To(BeTrue())
+				Expect(dbCluster.CreateID).To(Equal(dbClusterIdentifier))
+				Expect(dbCluster.CreateDBClusterDetails.Engine).To(Equal("aurora"))
+				Expect(dbCluster.CreateDBClusterDetails.DatabaseName).To(Equal(dbName))
+				Expect(dbCluster.CreateDBClusterDetails.MasterUsername).ToNot(BeEmpty())
+				Expect(dbCluster.CreateDBClusterDetails.MasterUserPassword).To(Equal(masterUserPassword))
+				Expect(dbCluster.CreateDBClusterDetails.Tags["Owner"]).To(Equal("Cloud Foundry"))
+				Expect(dbCluster.CreateDBClusterDetails.Tags["Created by"]).To(Equal("AWS RDS Service Broker"))
+				Expect(dbCluster.CreateDBClusterDetails.Tags).To(HaveKey("Created at"))
+				Expect(dbCluster.CreateDBClusterDetails.Tags["Service ID"]).To(Equal("Service-1"))
+				Expect(dbCluster.CreateDBClusterDetails.Tags["Plan ID"]).To(Equal("Plan-1"))
+				Expect(dbCluster.CreateDBClusterDetails.Tags["Organization ID"]).To(Equal("organization-id"))
+				Expect(dbCluster.CreateDBClusterDetails.Tags["Space ID"]).To(Equal("space-id"))
+				Expect(dbInstance.CreateDBInstanceDetails.DBClusterIdentifier).To(Equal(dbClusterIdentifier))
+				Expect(dbCluster.DeleteCalled).To(BeFalse())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when has DBClusterParameterGroupName", func() {
+				BeforeEach(func() {
+					rdsProperties1.DBClusterParameterGroupName = "test-db-cluster-parameter-group-name"
+				})
+
+				It("makes the proper calls", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(dbCluster.CreateDBClusterDetails.DBClusterParameterGroupName).To(Equal("test-db-cluster-parameter-group-name"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when creating the DB Instance fails", func() {
+				BeforeEach(func() {
+					dbInstance.CreateError = errors.New("operation failed")
+				})
+
+				It("deletes the DB Cluster", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(dbCluster.DeleteCalled).To(BeTrue())
+					Expect(dbCluster.DeleteID).To(Equal(dbClusterIdentifier))
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Update", func() {
+		var (
+			updateDetails     brokerapi.UpdateDetails
+			acceptsIncomplete bool
+		)
+
+		BeforeEach(func() {
+			updateDetails = brokerapi.UpdateDetails{
+				ServiceID:  "Service-2",
+				PlanID:     "Plan-2",
+				Parameters: map[string]interface{}{},
+				PreviousValues: brokerapi.PreviousValues{
+					PlanID:         "Plan-1",
+					ServiceID:      "Service-1",
+					OrganizationID: "organization-id",
+					SpaceID:        "space-id",
+				},
+			}
+			acceptsIncomplete = true
+		})
+
+		It("returns the proper response", func() {
+			asynch, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+			Expect(asynch).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("makes the proper calls", func() {
+			_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+			Expect(dbInstance.ModifyCalled).To(BeTrue())
+			Expect(dbInstance.ModifyID).To(Equal(dbInstanceIdentifier))
+			Expect(dbInstance.ModifyDBInstanceDetails.DBInstanceClass).To(Equal("db.m2.test"))
+			Expect(dbInstance.ModifyDBInstanceDetails.Engine).To(Equal("test-engine-2"))
+			Expect(dbInstance.ModifyDBInstanceDetails.Tags["Owner"]).To(Equal("Cloud Foundry"))
+			Expect(dbInstance.ModifyDBInstanceDetails.Tags["Updated by"]).To(Equal("AWS RDS Service Broker"))
+			Expect(dbInstance.ModifyDBInstanceDetails.Tags).To(HaveKey("Updated at"))
+			Expect(dbInstance.ModifyDBInstanceDetails.Tags["Service ID"]).To(Equal("Service-2"))
+			Expect(dbInstance.ModifyDBInstanceDetails.Tags["Plan ID"]).To(Equal("Plan-2"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when has AllocatedStorage", func() {
+			BeforeEach(func() {
+				rdsProperties2.AllocatedStorage = int64(100)
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.AllocatedStorage).To(Equal(int64(100)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.AllocatedStorage).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has AutoMinorVersionUpgrade", func() {
+			BeforeEach(func() {
+				rdsProperties2.AutoMinorVersionUpgrade = true
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.AutoMinorVersionUpgrade).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has AvailabilityZone", func() {
+			BeforeEach(func() {
+				rdsProperties2.AvailabilityZone = "test-az"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.AvailabilityZone).To(Equal("test-az"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.AvailabilityZone).To(Equal("test-az"))
+					Expect(dbCluster.ModifyDBClusterDetails.AvailabilityZones).To(Equal([]string{"test-az"}))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has BackupRetentionPeriod", func() {
+			BeforeEach(func() {
+				rdsProperties2.BackupRetentionPeriod = int64(7)
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(7)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbCluster.ModifyDBClusterDetails.BackupRetentionPeriod).To(Equal(int64(7)))
+					Expect(dbInstance.ModifyDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("but has BackupRetentionPeriod Parameter", func() {
+				BeforeEach(func() {
+					updateDetails.Parameters = map[string]interface{}{"backup_retention_period": 12}
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(12)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when Engine is Aurora", func() {
+					BeforeEach(func() {
+						rdsProperties2.Engine = "aurora"
+					})
+
+					It("makes the proper calls", func() {
+						_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+						Expect(dbCluster.ModifyDBClusterDetails.BackupRetentionPeriod).To(Equal(int64(12)))
+						Expect(dbInstance.ModifyDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(0)))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when has CharacterSetName", func() {
+			BeforeEach(func() {
+				rdsProperties2.CharacterSetName = "test-characterset-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.CharacterSetName).To(Equal("test-characterset-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.CharacterSetName).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has CopyTagsToSnapshot", func() {
+			BeforeEach(func() {
+				rdsProperties2.CopyTagsToSnapshot = true
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.CopyTagsToSnapshot).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBParameterGroupName", func() {
+			BeforeEach(func() {
+				rdsProperties2.DBParameterGroupName = "test-db-parameter-group-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.DBParameterGroupName).To(Equal("test-db-parameter-group-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has DBSecurityGroups", func() {
+			BeforeEach(func() {
+				rdsProperties2.DBSecurityGroups = []string{"test-db-security-group"}
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.DBSecurityGroups).To(Equal([]string{"test-db-security-group"}))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.DBSecurityGroups).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has DBSubnetGroupName", func() {
+			BeforeEach(func() {
+				rdsProperties2.DBSubnetGroupName = "test-db-subnet-group-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.DBSubnetGroupName).To(Equal("test-db-subnet-group-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbCluster.ModifyDBClusterDetails.DBSubnetGroupName).To(Equal("test-db-subnet-group-name"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has EngineVersion", func() {
+			BeforeEach(func() {
+				rdsProperties2.EngineVersion = "1.2.3"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.EngineVersion).To(Equal("1.2.3"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.EngineVersion).To(Equal("1.2.3"))
+					Expect(dbCluster.ModifyDBClusterDetails.EngineVersion).To(Equal("1.2.3"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has Iops", func() {
+			BeforeEach(func() {
+				rdsProperties2.Iops = int64(1000)
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.Iops).To(Equal(int64(1000)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.Iops).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has KmsKeyID", func() {
+			BeforeEach(func() {
+				rdsProperties2.KmsKeyID = "test-kms-key-id"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.KmsKeyID).To(Equal("test-kms-key-id"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.KmsKeyID).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has LicenseModel", func() {
+			BeforeEach(func() {
+				rdsProperties2.LicenseModel = "test-license-model"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.LicenseModel).To(Equal("test-license-model"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.LicenseModel).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has MultiAZ", func() {
+			BeforeEach(func() {
+				rdsProperties2.MultiAZ = true
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.MultiAZ).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.MultiAZ).To(BeFalse())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has OptionGroupName", func() {
+			BeforeEach(func() {
+				rdsProperties2.OptionGroupName = "test-option-group-name"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.OptionGroupName).To(Equal("test-option-group-name"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has Port", func() {
+			BeforeEach(func() {
+				rdsProperties2.Port = int64(3306)
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.Port).To(Equal(int64(3306)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbCluster.ModifyDBClusterDetails.Port).To(Equal(int64(3306)))
+					Expect(dbInstance.ModifyDBInstanceDetails.Port).To(Equal(int64(0)))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has PreferredBackupWindow", func() {
+			BeforeEach(func() {
+				rdsProperties2.PreferredBackupWindow = "test-preferred-backup-window"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbCluster.ModifyDBClusterDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window"))
+					Expect(dbInstance.ModifyDBInstanceDetails.PreferredBackupWindow).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("but has PreferredBackupWindow Parameter", func() {
+				BeforeEach(func() {
+					updateDetails.Parameters = map[string]interface{}{"preferred_backup_window": "test-preferred-backup-window-parameter"}
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window-parameter"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when Engine is Aurora", func() {
+					BeforeEach(func() {
+						rdsProperties2.Engine = "aurora"
+					})
+
+					It("makes the proper calls", func() {
+						_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+						Expect(dbCluster.ModifyDBClusterDetails.PreferredBackupWindow).To(Equal("test-preferred-backup-window-parameter"))
+						Expect(dbInstance.ModifyDBInstanceDetails.PreferredBackupWindow).To(Equal(""))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when has PreferredMaintenanceWindow", func() {
+			BeforeEach(func() {
+				rdsProperties2.PreferredMaintenanceWindow = "test-preferred-maintenance-window"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbCluster.ModifyDBClusterDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("but has PreferredMaintenanceWindow Parameter", func() {
+				BeforeEach(func() {
+					updateDetails.Parameters = map[string]interface{}{"preferred_maintenance_window": "test-preferred-maintenance-window-parameter"}
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window-parameter"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when Engine is Aurora", func() {
+					BeforeEach(func() {
+						rdsProperties2.Engine = "aurora"
+					})
+
+					It("makes the proper calls", func() {
+						_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+						Expect(dbCluster.ModifyDBClusterDetails.PreferredMaintenanceWindow).To(Equal("test-preferred-maintenance-window-parameter"))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when has PubliclyAccessible", func() {
+			BeforeEach(func() {
+				rdsProperties2.PubliclyAccessible = true
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.PubliclyAccessible).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when has StorageEncrypted", func() {
+			BeforeEach(func() {
+				rdsProperties2.StorageEncrypted = true
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.StorageEncrypted).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.StorageEncrypted).To(BeFalse())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has StorageType", func() {
+			BeforeEach(func() {
+				rdsProperties2.StorageType = "test-storage-type"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.StorageType).To(Equal("test-storage-type"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbInstance.ModifyDBInstanceDetails.StorageType).To(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when has VpcSecurityGroupIds", func() {
+			BeforeEach(func() {
+				rdsProperties2.VpcSecurityGroupIds = []string{"test-vpc-security-group-ids"}
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbInstance.ModifyDBInstanceDetails.VpcSecurityGroupIds).To(Equal([]string{"test-vpc-security-group-ids"}))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when Engine is Aurora", func() {
+				BeforeEach(func() {
+					rdsProperties2.Engine = "aurora"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbCluster.ModifyDBClusterDetails.VpcSecurityGroupIds).To(Equal([]string{"test-vpc-security-group-ids"}))
+					Expect(dbInstance.ModifyDBInstanceDetails.VpcSecurityGroupIds).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when request does not accept incomplete", func() {
+			BeforeEach(func() {
+				acceptsIncomplete = false
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(brokerapi.ErrAsyncRequired))
+			})
+		})
+
+		Context("when Parameters are not valid", func() {
+			BeforeEach(func() {
+				updateDetails.Parameters = map[string]interface{}{"backup_retention_period": "invalid"}
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("'backup_retention_period' expected type 'int64', got unconvertible type 'string'"))
+			})
+
+			Context("and user update parameters are not allowed", func() {
+				BeforeEach(func() {
+					allowUserUpdateParameters = false
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when Service is not found", func() {
+			BeforeEach(func() {
+				updateDetails.ServiceID = "unknown"
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Service 'unknown' not found"))
+			})
+		})
+
+		Context("when Plans is not updateable", func() {
+			BeforeEach(func() {
+				planUpdateable = false
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(brokerapi.ErrInstanceNotUpdateable))
+			})
+		})
+
+		Context("when Service Plan is not found", func() {
+			BeforeEach(func() {
+				updateDetails.PlanID = "unknown"
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Service Plan 'unknown' not found"))
+			})
+		})
+
+		Context("when modifying the DB Instance fails", func() {
+			BeforeEach(func() {
+				dbInstance.ModifyError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("when the DB Instance does not exists", func() {
+				BeforeEach(func() {
+					dbInstance.ModifyError = awsrds.ErrDBInstanceDoesNotExist
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+				})
+			})
+		})
+
+		Context("when Engine is Aurora", func() {
+			BeforeEach(func() {
+				rdsProperties2.Engine = "aurora"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(dbCluster.ModifyCalled).To(BeTrue())
+				Expect(dbCluster.ModifyID).To(Equal(dbClusterIdentifier))
+				Expect(dbCluster.ModifyDBClusterDetails.Engine).To(Equal("aurora"))
+				Expect(dbCluster.ModifyDBClusterDetails.Tags["Owner"]).To(Equal("Cloud Foundry"))
+				Expect(dbCluster.ModifyDBClusterDetails.Tags["Updated by"]).To(Equal("AWS RDS Service Broker"))
+				Expect(dbCluster.ModifyDBClusterDetails.Tags).To(HaveKey("Updated at"))
+				Expect(dbCluster.ModifyDBClusterDetails.Tags["Service ID"]).To(Equal("Service-2"))
+				Expect(dbCluster.ModifyDBClusterDetails.Tags["Plan ID"]).To(Equal("Plan-2"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when has DBClusterParameterGroupName", func() {
+				BeforeEach(func() {
+					rdsProperties2.DBClusterParameterGroupName = "test-db-cluster-parameter-group-name"
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+					Expect(dbCluster.ModifyDBClusterDetails.DBClusterParameterGroupName).To(Equal("test-db-cluster-parameter-group-name"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Deprovision", func() {
+		var (
+			deprovisionDetails brokerapi.DeprovisionDetails
+			acceptsIncomplete  bool
+		)
+
+		BeforeEach(func() {
+			deprovisionDetails = brokerapi.DeprovisionDetails{
+				ServiceID: "Service-1",
+				PlanID:    "Plan-1",
+			}
+			acceptsIncomplete = true
+		})
+
+		It("returns the proper response", func() {
+			asynch, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+			Expect(asynch).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("makes the proper calls", func() {
+			_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+			Expect(dbInstance.DeleteCalled).To(BeTrue())
+			Expect(dbInstance.DeleteID).To(Equal(dbInstanceIdentifier))
+			Expect(dbInstance.DeleteSkipFinalSnapshot).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when it does not skip final snaphot", func() {
+			BeforeEach(func() {
+				rdsProperties1.SkipFinalSnapshot = false
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+				Expect(dbInstance.DeleteCalled).To(BeTrue())
+				Expect(dbInstance.DeleteID).To(Equal(dbInstanceIdentifier))
+				Expect(dbInstance.DeleteSkipFinalSnapshot).To(BeFalse())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when request does not accept incomplete", func() {
+			BeforeEach(func() {
+				acceptsIncomplete = false
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(brokerapi.ErrAsyncRequired))
+			})
+		})
+
+		Context("when Service Plan is not found", func() {
+			BeforeEach(func() {
+				deprovisionDetails.PlanID = "unknown"
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Service Plan 'unknown' not found"))
+			})
+		})
+
+		Context("when deleting the DB Instance fails", func() {
+			BeforeEach(func() {
+				dbInstance.DeleteError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("when the DB instance does not exists", func() {
+				BeforeEach(func() {
+					dbInstance.DeleteError = awsrds.ErrDBInstanceDoesNotExist
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+				})
+			})
+		})
+
+		Context("when Engine is Aurora", func() {
+			BeforeEach(func() {
+				rdsProperties1.Engine = "aurora"
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+				Expect(dbCluster.DeleteCalled).To(BeTrue())
+				Expect(dbCluster.DeleteID).To(Equal(dbClusterIdentifier))
+				Expect(dbCluster.DeleteSkipFinalSnapshot).To(BeTrue())
+				Expect(dbInstance.DeleteSkipFinalSnapshot).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when it does not skip final snaphot", func() {
+				BeforeEach(func() {
+					rdsProperties1.SkipFinalSnapshot = false
+				})
+
+				It("makes the proper calls", func() {
+					_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+					Expect(dbCluster.DeleteSkipFinalSnapshot).To(BeFalse())
+					Expect(dbInstance.DeleteSkipFinalSnapshot).To(BeTrue())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when deleting the DB Instance fails", func() {
+				BeforeEach(func() {
+					dbCluster.DeleteError = errors.New("operation failed")
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+	})
+
+	var _ = Describe("Bind", func() {
+		var (
+			bindDetails brokerapi.BindDetails
+		)
+
+		BeforeEach(func() {
+			bindDetails = brokerapi.BindDetails{
+				ServiceID:  "Service-1",
+				PlanID:     "Plan-1",
+				AppGUID:    "Application-1",
+				Parameters: map[string]interface{}{},
+			}
+
+			dbInstance.DescribeDBInstanceDetails = awsrds.DBInstanceDetails{
+				Identifier:     dbInstanceIdentifier,
+				Address:        "endpoint-address",
+				Port:           3306,
+				DBName:         "test-db",
+				MasterUsername: "master-username",
+			}
+
+			dbCluster.DescribeDBClusterDetails = awsrds.DBClusterDetails{
+				Identifier:     dbClusterIdentifier,
+				Endpoint:       "endpoint-address",
+				Port:           3306,
+				DatabaseName:   "test-db",
+				MasterUsername: "master-username",
+			}
+		})
+
+		It("returns the proper response", func() {
+			bindingResponse, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+			credentials := bindingResponse.Credentials.(*brokerapi.CredentialsHash)
+			Expect(bindingResponse.SyslogDrainURL).To(BeEmpty())
+			Expect(credentials.Host).To(Equal("endpoint-address"))
+			Expect(credentials.Port).To(Equal(int64(3306)))
+			Expect(credentials.Name).To(Equal("test-db"))
+			Expect(credentials.Username).To(Equal(dbUsername))
+			Expect(credentials.Password).ToNot(BeEmpty())
+			Expect(credentials.URI).To(ContainSubstring("@endpoint-address:3306/test-db?reconnect=true"))
+			Expect(credentials.JDBCURI).To(ContainSubstring("jdbc:fake://endpoint-address:3306/test-db?user=" + dbUsername + "&password="))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("makes the proper calls", func() {
+			_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+			Expect(dbCluster.DescribeCalled).To(BeFalse())
+			Expect(dbInstance.DescribeCalled).To(BeTrue())
+			Expect(dbInstance.DescribeID).To(Equal(dbInstanceIdentifier))
+			Expect(sqlProvider.GetSQLEngineCalled).To(BeTrue())
+			Expect(sqlProvider.GetSQLEngineEngine).To(Equal("test-engine-1"))
+			Expect(sqlEngine.OpenCalled).To(BeTrue())
+			Expect(sqlEngine.OpenAddress).To(Equal("endpoint-address"))
+			Expect(sqlEngine.OpenPort).To(Equal(int64(3306)))
+			Expect(sqlEngine.OpenDBName).To(Equal("test-db"))
+			Expect(sqlEngine.OpenUsername).To(Equal("master-username"))
+			Expect(sqlEngine.OpenPassword).ToNot(BeEmpty())
+			Expect(sqlEngine.CreateDBCalled).To(BeFalse())
+			Expect(sqlEngine.CreateUserCalled).To(BeTrue())
+			Expect(sqlEngine.CreateUserUsername).To(Equal(dbUsername))
+			Expect(sqlEngine.CreateUserPassword).ToNot(BeEmpty())
+			Expect(sqlEngine.GrantPrivilegesCalled).To(BeTrue())
+			Expect(sqlEngine.GrantPrivilegesDBName).To(Equal("test-db"))
+			Expect(sqlEngine.GrantPrivilegesUsername).To(Equal(dbUsername))
+			Expect(sqlEngine.CloseCalled).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when Parameters are not valid", func() {
+			BeforeEach(func() {
+				bindDetails.Parameters = map[string]interface{}{"dbname": true}
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("'dbname' expected type 'string', got unconvertible type 'bool'"))
+			})
+
+			Context("and user bind parameters are not allowed", func() {
+				BeforeEach(func() {
+					allowUserBindParameters = false
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when Service is not found", func() {
+			BeforeEach(func() {
+				bindDetails.ServiceID = "unknown"
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Service 'unknown' not found"))
+			})
+		})
+
+		Context("when Service is not bindable", func() {
+			BeforeEach(func() {
+				serviceBindable = false
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(brokerapi.ErrInstanceNotBindable))
+			})
+		})
+
+		Context("when Service Plan is not found", func() {
+			BeforeEach(func() {
+				bindDetails.PlanID = "unknown"
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Service Plan 'unknown' not found"))
+			})
+		})
+
+		Context("when describing the DB Instance fails", func() {
+			BeforeEach(func() {
+				dbInstance.DescribeError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("when the DB Instance does not exists", func() {
+				BeforeEach(func() {
+					dbInstance.DescribeError = awsrds.ErrDBInstanceDoesNotExist
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+				})
+			})
+		})
+
+		Context("when Engine is aurora", func() {
+			BeforeEach(func() {
+				rdsProperties1.Engine = "aurora"
+			})
+
+			It("does not describe the DB Instance", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dbInstance.DescribeCalled).To(BeFalse())
+			})
+
+			Context("when describing the DB Cluster fails", func() {
+				BeforeEach(func() {
+					dbCluster.DescribeError = errors.New("operation failed")
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("operation failed"))
+				})
+
+				Context("when the DB Cluster does not exists", func() {
+					BeforeEach(func() {
+						dbCluster.DescribeError = awsrds.ErrDBInstanceDoesNotExist
+					})
+
+					It("returns the proper error", func() {
+						_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+					})
+				})
+			})
+		})
+
+		Context("when getting the SQL Engine fails", func() {
+			BeforeEach(func() {
+				sqlProvider.GetSQLEngineError = errors.New("Engine 'unknown' not supported")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Engine 'unknown' not supported"))
+			})
+		})
+
+		Context("when opening a DB connection fails", func() {
+			BeforeEach(func() {
+				sqlEngine.OpenError = errors.New("Failed to open sqlEngine")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Failed to open sqlEngine"))
+			})
+		})
+
+		Context("when DBNname Parameter is set", func() {
+			BeforeEach(func() {
+				bindDetails.Parameters = map[string]interface{}{"dbname": "my-test-db"}
+			})
+
+			It("returns the proper response", func() {
+				bindingResponse, _ := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				credentials := bindingResponse.Credentials.(*brokerapi.CredentialsHash)
+				Expect(bindingResponse.SyslogDrainURL).To(BeEmpty())
+				Expect(credentials.Name).To(Equal("my-test-db"))
+			})
+
+			It("creates the DB with the proper name", func() {
+				rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(sqlEngine.CreateDBCalled).To(BeTrue())
+				Expect(sqlEngine.CreateDBDBName).To(Equal("my-test-db"))
+				Expect(sqlEngine.GrantPrivilegesDBName).To(Equal("my-test-db"))
+			})
+
+			Context("when creating the DB fails", func() {
+				BeforeEach(func() {
+					sqlEngine.CreateDBError = errors.New("Failed to create sqlEngine")
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("Failed to create sqlEngine"))
+					Expect(sqlEngine.CloseCalled).To(BeTrue())
+				})
+			})
+		})
+
+		Context("when creating a DB user fails", func() {
+			BeforeEach(func() {
+				sqlEngine.CreateUserError = errors.New("Failed to create user")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Failed to create user"))
+				Expect(sqlEngine.CloseCalled).To(BeTrue())
+			})
+		})
+
+		Context("when granting privileges fails", func() {
+			BeforeEach(func() {
+				sqlEngine.GrantPrivilegesError = errors.New("Failed to grant privileges")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Failed to grant privileges"))
+				Expect(sqlEngine.CloseCalled).To(BeTrue())
+			})
+		})
+	})
+
+	var _ = Describe("Unbind", func() {
+		var (
+			unbindDetails brokerapi.UnbindDetails
+		)
+
+		BeforeEach(func() {
+			unbindDetails = brokerapi.UnbindDetails{
+				ServiceID: "Service-1",
+				PlanID:    "Plan-1",
+			}
+
+			dbInstance.DescribeDBInstanceDetails = awsrds.DBInstanceDetails{
+				Identifier:     dbInstanceIdentifier,
+				Address:        "endpoint-address",
+				Port:           3306,
+				DBName:         "test-db",
+				MasterUsername: "master-username",
+			}
+
+			dbCluster.DescribeDBClusterDetails = awsrds.DBClusterDetails{
+				Identifier:     dbClusterIdentifier,
+				Endpoint:       "endpoint-address",
+				Port:           3306,
+				DatabaseName:   "test-db",
+				MasterUsername: "master-username",
+			}
+		})
+
+		It("makes the proper calls", func() {
+			err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+			Expect(dbCluster.DescribeCalled).To(BeFalse())
+			Expect(dbInstance.DescribeCalled).To(BeTrue())
+			Expect(dbInstance.DescribeID).To(Equal(dbInstanceIdentifier))
+			Expect(sqlProvider.GetSQLEngineCalled).To(BeTrue())
+			Expect(sqlProvider.GetSQLEngineEngine).To(Equal("test-engine-1"))
+			Expect(sqlEngine.OpenCalled).To(BeTrue())
+			Expect(sqlEngine.OpenAddress).To(Equal("endpoint-address"))
+			Expect(sqlEngine.OpenPort).To(Equal(int64(3306)))
+			Expect(sqlEngine.OpenDBName).To(Equal("test-db"))
+			Expect(sqlEngine.OpenUsername).To(Equal("master-username"))
+			Expect(sqlEngine.OpenPassword).ToNot(BeEmpty())
+			Expect(sqlEngine.PrivilegesCalled).To(BeTrue())
+			Expect(sqlEngine.RevokePrivilegesCalled).To(BeFalse())
+			Expect(sqlEngine.DropDBCalled).To(BeFalse())
+			Expect(sqlEngine.DropUserCalled).To(BeTrue())
+			Expect(sqlEngine.DropUserUsername).To(Equal(dbUsername))
+			Expect(sqlEngine.CloseCalled).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when Service Plan is not found", func() {
+			BeforeEach(func() {
+				unbindDetails.PlanID = "unknown"
+			})
+
+			It("returns the proper error", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Service Plan 'unknown' not found"))
+			})
+		})
+
+		Context("when describing the DB Instance fails", func() {
+			BeforeEach(func() {
+				dbInstance.DescribeError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("when the DB Instance does not exists", func() {
+				BeforeEach(func() {
+					dbInstance.DescribeError = awsrds.ErrDBInstanceDoesNotExist
+				})
+
+				It("returns the proper error", func() {
+					err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+				})
+			})
+		})
+
+		Context("when Engine is aurora", func() {
+			BeforeEach(func() {
+				rdsProperties1.Engine = "aurora"
+			})
+
+			It("does not describe the DB Instance", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dbInstance.DescribeCalled).To(BeFalse())
+			})
+
+			Context("when describing the DB Cluster fails", func() {
+				BeforeEach(func() {
+					dbCluster.DescribeError = errors.New("operation failed")
+				})
+
+				It("returns the proper error", func() {
+					err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("operation failed"))
+				})
+
+				Context("when the DB Cluster does not exists", func() {
+					BeforeEach(func() {
+						dbCluster.DescribeError = awsrds.ErrDBInstanceDoesNotExist
+					})
+
+					It("returns the proper error", func() {
+						err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+					})
+				})
+			})
+		})
+
+		Context("when getting the SQL Engine fails", func() {
+			BeforeEach(func() {
+				sqlProvider.GetSQLEngineError = errors.New("SQL Engine 'unknown' not supported")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("SQL Engine 'unknown' not supported"))
+			})
+		})
+
+		Context("when opening a DB connection fails", func() {
+			BeforeEach(func() {
+				sqlEngine.OpenError = errors.New("Failed to open sqlEngine")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Failed to open sqlEngine"))
+			})
+		})
+
+		Context("when getting privileges fails", func() {
+			BeforeEach(func() {
+				sqlEngine.PrivilegesError = errors.New("Failed to get privileges")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Failed to get privileges"))
+				Expect(sqlEngine.CloseCalled).To(BeTrue())
+			})
+		})
+
+		Context("when user has privileges over a DB", func() {
+			BeforeEach(func() {
+				sqlEngine.PrivilegesPrivileges = map[string][]string{"test-db": []string{dbUsername}}
+			})
+
+			It("makes the proper calls", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(sqlEngine.RevokePrivilegesCalled).To(BeTrue())
+				Expect(sqlEngine.RevokePrivilegesDBName).To(Equal("test-db"))
+				Expect(sqlEngine.RevokePrivilegesUsername).To(Equal(dbUsername))
+				Expect(sqlEngine.DropDBCalled).To(BeFalse())
+				Expect(sqlEngine.CloseCalled).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("when revoking privileges fails", func() {
+				BeforeEach(func() {
+					sqlEngine.RevokePrivilegesError = errors.New("Failed to revoke privileges")
+				})
+
+				It("returns the proper error", func() {
+					err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("Failed to revoke privileges"))
+					Expect(sqlEngine.CloseCalled).To(BeTrue())
+				})
+			})
+
+			Context("and the db is not the master db", func() {
+				BeforeEach(func() {
+					sqlEngine.PrivilegesPrivileges = map[string][]string{"another-test-db": []string{dbUsername}}
+				})
+
+				It("makes the proper calls", func() {
+					err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+					Expect(sqlEngine.RevokePrivilegesCalled).To(BeTrue())
+					Expect(sqlEngine.RevokePrivilegesDBName).To(Equal("another-test-db"))
+					Expect(sqlEngine.RevokePrivilegesUsername).To(Equal(dbUsername))
+					Expect(sqlEngine.DropDBCalled).To(BeTrue())
+					Expect(sqlEngine.DropDBDBName).To(Equal("another-test-db"))
+					Expect(sqlEngine.CloseCalled).To(BeTrue())
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("when droping the DB fails", func() {
+					BeforeEach(func() {
+						sqlEngine.DropDBError = errors.New("Failed to drop db")
+					})
+
+					It("returns the proper error", func() {
+						err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(Equal("Failed to drop db"))
+						Expect(sqlEngine.CloseCalled).To(BeTrue())
+					})
+				})
+
+				Context("but there are other users with grants over the db", func() {
+					BeforeEach(func() {
+						sqlEngine.PrivilegesPrivileges = map[string][]string{"another-test-db": []string{dbUsername, "another-user"}}
+					})
+
+					It("makes the proper calls", func() {
+						err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+						Expect(sqlEngine.RevokePrivilegesCalled).To(BeTrue())
+						Expect(sqlEngine.RevokePrivilegesDBName).To(Equal("another-test-db"))
+						Expect(sqlEngine.RevokePrivilegesUsername).To(Equal(dbUsername))
+						Expect(sqlEngine.DropDBCalled).To(BeFalse())
+						Expect(sqlEngine.CloseCalled).To(BeTrue())
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when deleting a user fails", func() {
+			BeforeEach(func() {
+				sqlEngine.DropUserError = errors.New("Failed to delete user")
+			})
+
+			It("returns the proper error", func() {
+				err := rdsBroker.Unbind(instanceID, bindingID, unbindDetails)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Failed to delete user"))
+				Expect(sqlEngine.CloseCalled).To(BeTrue())
+			})
+		})
+	})
+
+	var _ = Describe("LastOperation", func() {
+		var (
+			dbInstanceStatus            string
+			lastOperationState          string
+			properLastOperationResponse brokerapi.LastOperationResponse
+		)
+
+		JustBeforeEach(func() {
+			dbInstance.DescribeDBInstanceDetails = awsrds.DBInstanceDetails{
+				Identifier:     dbInstanceIdentifier,
+				Engine:         "test-engine",
+				Address:        "endpoint-address",
+				Port:           3306,
+				DBName:         "test-db",
+				MasterUsername: "master-username",
+				Status:         dbInstanceStatus,
+			}
+
+			properLastOperationResponse = brokerapi.LastOperationResponse{
+				State:       lastOperationState,
+				Description: "DB Instance '" + dbInstanceIdentifier + "' status is '" + dbInstanceStatus + "'",
+			}
+		})
+
+		Context("when describing the DB Instance fails", func() {
+			BeforeEach(func() {
+				dbInstance.DescribeError = errors.New("operation failed")
+			})
+
+			It("returns the proper error", func() {
+				_, err := rdsBroker.LastOperation(instanceID)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("operation failed"))
+			})
+
+			Context("when the DB Instance does not exists", func() {
+				BeforeEach(func() {
+					dbInstance.DescribeError = awsrds.ErrDBInstanceDoesNotExist
+				})
+
+				It("returns the proper error", func() {
+					_, err := rdsBroker.LastOperation(instanceID)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+				})
+			})
+		})
+
+		Context("when last operation is still in progress", func() {
+			BeforeEach(func() {
+				dbInstanceStatus = "creating"
+				lastOperationState = brokerapi.LastOperationInProgress
+			})
+
+			It("returns the proper LastOperationResponse", func() {
+				lastOperationResponse, err := rdsBroker.LastOperation(instanceID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
+			})
+		})
+
+		Context("when last operation failed", func() {
+			BeforeEach(func() {
+				dbInstanceStatus = "failed"
+				lastOperationState = brokerapi.LastOperationFailed
+			})
+
+			It("returns the proper LastOperationResponse", func() {
+				lastOperationResponse, err := rdsBroker.LastOperation(instanceID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
+			})
+		})
+
+		Context("when last operation succeeded", func() {
+			BeforeEach(func() {
+				dbInstanceStatus = "available"
+				lastOperationState = brokerapi.LastOperationSucceeded
+			})
+
+			It("returns the proper LastOperationResponse", func() {
+				lastOperationResponse, err := rdsBroker.LastOperation(instanceID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
+			})
+
+			Context("but has pending modifications", func() {
+				JustBeforeEach(func() {
+					dbInstance.DescribeDBInstanceDetails.PendingModifications = true
+
+					properLastOperationResponse = brokerapi.LastOperationResponse{
+						State:       brokerapi.LastOperationInProgress,
+						Description: "DB Instance '" + dbInstanceIdentifier + "' has pending modifications",
+					}
+				})
+
+				It("returns the proper LastOperationResponse", func() {
+					lastOperationResponse, err := rdsBroker.LastOperation(instanceID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
+				})
+			})
+		})
+	})
+})

--- a/rdsbroker/catalog.go
+++ b/rdsbroker/catalog.go
@@ -1,0 +1,185 @@
+package rdsbroker
+
+import (
+	"fmt"
+	"strings"
+)
+
+const minAllocatedStorage = 5
+const maxAllocatedStorage = 6144
+
+type Catalog struct {
+	Services []Service `json:"services,omitempty"`
+}
+
+type Service struct {
+	ID              string           `json:"id"`
+	Name            string           `json:"name"`
+	Description     string           `json:"description"`
+	Bindable        bool             `json:"bindable,omitempty"`
+	Tags            []string         `json:"tags,omitempty"`
+	Metadata        *ServiceMetadata `json:"metadata,omitempty"`
+	Requires        []string         `json:"requires,omitempty"`
+	PlanUpdateable  bool             `json:"plan_updateable"`
+	Plans           []ServicePlan    `json:"plans,omitempty"`
+	DashboardClient *DashboardClient `json:"dashboard_client,omitempty"`
+}
+
+type ServiceMetadata struct {
+	DisplayName         string `json:"displayName,omitempty"`
+	ImageURL            string `json:"imageUrl,omitempty"`
+	LongDescription     string `json:"longDescription,omitempty"`
+	ProviderDisplayName string `json:"providerDisplayName,omitempty"`
+	DocumentationURL    string `json:"documentationUrl,omitempty"`
+	SupportURL          string `json:"supportUrl,omitempty"`
+}
+
+type ServicePlan struct {
+	ID            string               `json:"id"`
+	Name          string               `json:"name"`
+	Description   string               `json:"description"`
+	Metadata      *ServicePlanMetadata `json:"metadata,omitempty"`
+	Free          bool                 `json:"free"`
+	RDSProperties RDSProperties        `json:"rds_properties,omitempty"`
+}
+
+type ServicePlanMetadata struct {
+	Bullets     []string `json:"bullets,omitempty"`
+	Costs       []Cost   `json:"costs,omitempty"`
+	DisplayName string   `json:"displayName,omitempty"`
+}
+
+type DashboardClient struct {
+	ID          string `json:"id,omitempty"`
+	Secret      string `json:"secret,omitempty"`
+	RedirectURI string `json:"redirect_uri,omitempty"`
+}
+
+type Cost struct {
+	Amount map[string]interface{} `json:"amount,omitempty"`
+	Unit   string                 `json:"unit,omitempty"`
+}
+
+type RDSProperties struct {
+	DBInstanceClass             string   `json:"db_instance_class"`
+	Engine                      string   `json:"engine"`
+	EngineVersion               string   `json:"engine_version"`
+	AllocatedStorage            int64    `json:"allocated_storage"`
+	AutoMinorVersionUpgrade     bool     `json:"auto_minor_version_upgrade,omitempty"`
+	AvailabilityZone            string   `json:"availability_zone,omitempty"`
+	BackupRetentionPeriod       int64    `json:"backup_retention_period,omitempty"`
+	CharacterSetName            string   `json:"character_set_name,omitempty"`
+	DBParameterGroupName        string   `json:"db_parameter_group_name,omitempty"`
+	DBClusterParameterGroupName string   `json:"db_cluster_parameter_group_name,omitempty"`
+	DBSecurityGroups            []string `json:"db_security_groups,omitempty"`
+	DBSubnetGroupName           string   `json:"db_subnet_group_name,omitempty"`
+	LicenseModel                string   `json:"license_model,omitempty"`
+	MultiAZ                     bool     `json:"multi_az,omitempty"`
+	OptionGroupName             string   `json:"option_group_name,omitempty"`
+	Port                        int64    `json:"port,omitempty"`
+	PreferredBackupWindow       string   `json:"preferred_backup_window,omitempty"`
+	PreferredMaintenanceWindow  string   `json:"preferred_maintenance_window,omitempty"`
+	PubliclyAccessible          bool     `json:"publicly_accessible,omitempty"`
+	StorageEncrypted            bool     `json:"storage_encrypted,omitempty"`
+	KmsKeyID                    string   `json:"kms_key_id,omitempty"`
+	StorageType                 string   `json:"storage_type,omitempty"`
+	Iops                        int64    `json:"iops,omitempty"`
+	VpcSecurityGroupIds         []string `json:"vpc_security_group_ids,omitempty"`
+	CopyTagsToSnapshot          bool     `json:"copy_tags_to_snapshot,omitempty"`
+	SkipFinalSnapshot           bool     `json:"skip_final_snapshot,omitempty"`
+}
+
+func (c Catalog) Validate() error {
+	for _, service := range c.Services {
+		if err := service.Validate(); err != nil {
+			return fmt.Errorf("Validating Services configuration: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func (c Catalog) FindService(serviceID string) (service Service, found bool) {
+	for _, service := range c.Services {
+		if service.ID == serviceID {
+			return service, true
+		}
+	}
+
+	return service, false
+}
+
+func (c Catalog) FindServicePlan(planID string) (plan ServicePlan, found bool) {
+	for _, service := range c.Services {
+		for _, plan := range service.Plans {
+			if plan.ID == planID {
+				return plan, true
+			}
+		}
+	}
+
+	return plan, false
+}
+
+func (s Service) Validate() error {
+	if s.ID == "" {
+		return fmt.Errorf("Must provide a non-empty ID (%+v)", s)
+	}
+
+	if s.Name == "" {
+		return fmt.Errorf("Must provide a non-empty Name (%+v)", s)
+	}
+
+	if s.Description == "" {
+		return fmt.Errorf("Must provide a non-empty Description (%+v)", s)
+	}
+
+	for _, servicePlan := range s.Plans {
+		if err := servicePlan.Validate(); err != nil {
+			return fmt.Errorf("Validating Plans configuration: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func (sp ServicePlan) Validate() error {
+	if sp.ID == "" {
+		return fmt.Errorf("Must provide a non-empty ID (%+v)", sp)
+	}
+
+	if sp.Name == "" {
+		return fmt.Errorf("Must provide a non-empty Name (%+v)", sp)
+	}
+
+	if sp.Description == "" {
+		return fmt.Errorf("Must provide a non-empty Description (%+v)", sp)
+	}
+
+	if err := sp.RDSProperties.Validate(); err != nil {
+		return fmt.Errorf("Validating RDS Properties configuration: %s", err)
+	}
+
+	return nil
+}
+
+func (rp RDSProperties) Validate() error {
+	if rp.DBInstanceClass == "" {
+		return fmt.Errorf("Must provide a non-empty DBInstanceClass (%+v)", rp)
+	}
+
+	if rp.Engine == "" {
+		return fmt.Errorf("Must provide a non-empty Engine (%+v)", rp)
+	}
+
+	switch strings.ToLower(rp.Engine) {
+	case "aurora":
+	case "mariadb":
+	case "mysql":
+	case "postgres":
+	default:
+		return fmt.Errorf("This broker does not support RDS engine '%s' (%+v)", rp.Engine, rp)
+	}
+
+	return nil
+}

--- a/rdsbroker/catalog_test.go
+++ b/rdsbroker/catalog_test.go
@@ -1,0 +1,255 @@
+package rdsbroker_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/rdsbroker"
+)
+
+var _ = Describe("Catalog", func() {
+	var (
+		catalog Catalog
+
+		plan1 = ServicePlan{ID: "Plan-1"}
+		plan2 = ServicePlan{ID: "Plan-2"}
+
+		service1 = Service{ID: "Service-1", Plans: []ServicePlan{plan1}}
+		service2 = Service{ID: "Service-2", Plans: []ServicePlan{plan2}}
+	)
+
+	Describe("Validate", func() {
+		BeforeEach(func() {
+			catalog = Catalog{}
+		})
+
+		It("does not return error if all fields are valid", func() {
+			err := catalog.Validate()
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if Services are not valid", func() {
+			catalog.Services = []Service{
+				Service{},
+			}
+
+			err := catalog.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Validating Services configuration"))
+		})
+	})
+
+	Describe("FindService", func() {
+		BeforeEach(func() {
+			catalog = Catalog{
+				Services: []Service{service1, service2},
+			}
+		})
+
+		It("returns true and the Service if it is found", func() {
+			service, found := catalog.FindService("Service-1")
+			Expect(service).To(Equal(service1))
+			Expect(found).To(BeTrue())
+		})
+
+		It("returns false if it is not found", func() {
+			_, found := catalog.FindService("Service-?")
+			Expect(found).To(BeFalse())
+		})
+	})
+
+	Describe("FindServicePlan", func() {
+		BeforeEach(func() {
+			catalog = Catalog{
+				Services: []Service{service1, service2},
+			}
+		})
+
+		It("returns true and the Service Plan if it is found", func() {
+			plan, found := catalog.FindServicePlan("Plan-1")
+			Expect(plan).To(Equal(plan1))
+			Expect(found).To(BeTrue())
+		})
+
+		It("returns false if it is not found", func() {
+			_, found := catalog.FindServicePlan("Plan-?")
+			Expect(found).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("Service", func() {
+	var (
+		service Service
+
+		validService = Service{
+			ID:              "Service-1",
+			Name:            "Service 1",
+			Description:     "Service 1 description",
+			Bindable:        true,
+			Tags:            []string{"service"},
+			Metadata:        &ServiceMetadata{},
+			Requires:        []string{"syslog"},
+			PlanUpdateable:  true,
+			Plans:           []ServicePlan{},
+			DashboardClient: &DashboardClient{},
+		}
+	)
+
+	BeforeEach(func() {
+		service = validService
+	})
+
+	Describe("Validate", func() {
+		It("does not return error if all fields are valid", func() {
+			err := service.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if ID is empty", func() {
+			service.ID = ""
+
+			err := service.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty ID"))
+		})
+
+		It("returns error if Name is empty", func() {
+			service.Name = ""
+
+			err := service.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Name"))
+		})
+
+		It("returns error if Description is empty", func() {
+			service.Description = ""
+
+			err := service.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Description"))
+		})
+
+		It("returns error if Plans are not valid", func() {
+			service.Plans = []ServicePlan{
+				ServicePlan{},
+			}
+
+			err := service.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Validating Plans configuration"))
+		})
+	})
+})
+
+var _ = Describe("ServicePlan", func() {
+	var (
+		servicePlan ServicePlan
+
+		validServicePlan = ServicePlan{
+			ID:          "Plan-1",
+			Name:        "Plan 1",
+			Description: "Plan-1 description",
+			Metadata:    &ServicePlanMetadata{},
+			Free:        true,
+			RDSProperties: RDSProperties{
+				DBInstanceClass:  "db.m3.medium",
+				Engine:           "MySQL",
+				EngineVersion:    "5.6.23",
+				AllocatedStorage: 5,
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		servicePlan = validServicePlan
+	})
+
+	Describe("Validate", func() {
+		It("does not return error if all fields are valid", func() {
+			err := servicePlan.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if ID is empty", func() {
+			servicePlan.ID = ""
+
+			err := servicePlan.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty ID"))
+		})
+
+		It("returns error if Name is empty", func() {
+			servicePlan.Name = ""
+
+			err := servicePlan.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Name"))
+		})
+
+		It("returns error if Description is empty", func() {
+			servicePlan.Description = ""
+
+			err := servicePlan.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Description"))
+		})
+
+		It("returns error if RDSProperties are not valid", func() {
+			servicePlan.RDSProperties = RDSProperties{}
+
+			err := servicePlan.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Validating RDS Properties configuration"))
+		})
+	})
+})
+
+var _ = Describe("RDSProperties", func() {
+	var (
+		rdsProperties RDSProperties
+
+		validRDSProperties = RDSProperties{
+			DBInstanceClass:  "db.m3.medium",
+			Engine:           "MySQL",
+			EngineVersion:    "5.6.23",
+			AllocatedStorage: 5,
+		}
+	)
+
+	BeforeEach(func() {
+		rdsProperties = validRDSProperties
+	})
+
+	Describe("Validate", func() {
+		It("does not return error if all fields are valid", func() {
+			err := rdsProperties.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if DBInstanceClass is empty", func() {
+			rdsProperties.DBInstanceClass = ""
+
+			err := rdsProperties.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty DBInstanceClass"))
+		})
+
+		It("returns error if Engine is empty", func() {
+			rdsProperties.Engine = ""
+
+			err := rdsProperties.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Engine"))
+		})
+
+		It("returns error if Engine is not supported", func() {
+			rdsProperties.Engine = "unsupported"
+
+			err := rdsProperties.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("This broker does not support RDS engine"))
+		})
+	})
+})

--- a/rdsbroker/config.go
+++ b/rdsbroker/config.go
@@ -1,0 +1,31 @@
+package rdsbroker
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Config struct {
+	Region                       string  `json:"region"`
+	DBPrefix                     string  `json:"db_prefix"`
+	AllowUserProvisionParameters bool    `json:"allow_user_provision_parameters"`
+	AllowUserUpdateParameters    bool    `json:"allow_user_update_parameters"`
+	AllowUserBindParameters      bool    `json:"allow_user_bind_parameters"`
+	Catalog                      Catalog `json:"catalog"`
+}
+
+func (c Config) Validate() error {
+	if c.Region == "" {
+		return errors.New("Must provide a non-empty Region")
+	}
+
+	if c.DBPrefix == "" {
+		return errors.New("Must provide a non-empty DBPrefix")
+	}
+
+	if err := c.Catalog.Validate(); err != nil {
+		return fmt.Errorf("Validating Catalog configuration: %s", err)
+	}
+
+	return nil
+}

--- a/rdsbroker/config_test.go
+++ b/rdsbroker/config_test.go
@@ -1,0 +1,67 @@
+package rdsbroker_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/rdsbroker"
+)
+
+var _ = Describe("Config", func() {
+	var (
+		config Config
+
+		validConfig = Config{
+			Region:   "rds-region",
+			DBPrefix: "cf",
+			Catalog: Catalog{
+				[]Service{
+					Service{
+						ID:          "service-1",
+						Name:        "Service 1",
+						Description: "Service 1 description",
+					},
+				},
+			},
+		}
+	)
+
+	Describe("Validate", func() {
+		BeforeEach(func() {
+			config = validConfig
+		})
+
+		It("does not return error if all sections are valid", func() {
+			err := config.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if Region is not valid", func() {
+			config.Region = ""
+
+			err := config.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Region"))
+		})
+
+		It("returns error if DBPrefix is not valid", func() {
+			config.DBPrefix = ""
+
+			err := config.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty DBPrefix"))
+		})
+
+		It("returns error if Catalog is not valid", func() {
+			config.Catalog = Catalog{
+				[]Service{
+					Service{},
+				},
+			}
+
+			err := config.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Validating Catalog configuration"))
+		})
+	})
+})

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -1,0 +1,20 @@
+package rdsbroker
+
+type ProvisionParameters struct {
+	BackupRetentionPeriod      int64  `mapstructure:"backup_retention_period"`
+	CharacterSetName           string `mapstructure:"character_set_name"`
+	DBName                     string `mapstructure:"dbname"`
+	PreferredBackupWindow      string `mapstructure:"preferred_backup_window"`
+	PreferredMaintenanceWindow string `mapstructure:"preferred_maintenance_window"`
+}
+
+type UpdateParameters struct {
+	ApplyImmediately           bool   `mapstructure:"apply_immediately"`
+	BackupRetentionPeriod      int64  `mapstructure:"backup_retention_period"`
+	PreferredBackupWindow      string `mapstructure:"preferred_backup_window"`
+	PreferredMaintenanceWindow string `mapstructure:"preferred_maintenance_window"`
+}
+
+type BindParameters struct {
+	DBName string `mapstructure:"dbname"`
+}

--- a/sqlengine/fakes/fake_provider.go
+++ b/sqlengine/fakes/fake_provider.go
@@ -1,0 +1,19 @@
+package fakes
+
+import (
+	"github.com/cf-platform-eng/sqs-broker/sqlengine"
+)
+
+type FakeProvider struct {
+	GetSQLEngineCalled    bool
+	GetSQLEngineEngine    string
+	GetSQLEngineSQLEngine sqlengine.SQLEngine
+	GetSQLEngineError     error
+}
+
+func (f *FakeProvider) GetSQLEngine(engine string) (sqlengine.SQLEngine, error) {
+	f.GetSQLEngineCalled = true
+	f.GetSQLEngineEngine = engine
+
+	return f.GetSQLEngineSQLEngine, f.GetSQLEngineError
+}

--- a/sqlengine/fakes/fake_sql_engine.go
+++ b/sqlengine/fakes/fake_sql_engine.go
@@ -1,0 +1,133 @@
+package fakes
+
+import (
+	"fmt"
+)
+
+type FakeSQLEngine struct {
+	OpenCalled   bool
+	OpenAddress  string
+	OpenPort     int64
+	OpenDBName   string
+	OpenUsername string
+	OpenPassword string
+	OpenError    error
+
+	CloseCalled bool
+
+	ExistsDBCalled bool
+	ExistsDBDBName string
+	ExistsDBError  error
+
+	CreateDBCalled bool
+	CreateDBDBName string
+	CreateDBError  error
+
+	DropDBCalled bool
+	DropDBDBName string
+	DropDBError  error
+
+	CreateUserCalled   bool
+	CreateUserUsername string
+	CreateUserPassword string
+	CreateUserError    error
+
+	DropUserCalled   bool
+	DropUserUsername string
+	DropUserError    error
+
+	PrivilegesCalled     bool
+	PrivilegesPrivileges map[string][]string
+	PrivilegesError      error
+
+	GrantPrivilegesCalled   bool
+	GrantPrivilegesDBName   string
+	GrantPrivilegesUsername string
+	GrantPrivilegesError    error
+
+	RevokePrivilegesCalled   bool
+	RevokePrivilegesDBName   string
+	RevokePrivilegesUsername string
+	RevokePrivilegesError    error
+}
+
+func (f *FakeSQLEngine) Open(address string, port int64, dbname string, username string, password string) error {
+	f.OpenCalled = true
+	f.OpenAddress = address
+	f.OpenPort = port
+	f.OpenDBName = dbname
+	f.OpenUsername = username
+	f.OpenPassword = password
+
+	return f.OpenError
+}
+
+func (f *FakeSQLEngine) Close() {
+	f.CloseCalled = true
+}
+
+func (f *FakeSQLEngine) ExistsDB(dbname string) (bool, error) {
+	f.ExistsDBCalled = true
+	f.ExistsDBDBName = dbname
+
+	return true, f.ExistsDBError
+}
+
+func (f *FakeSQLEngine) CreateDB(dbname string) error {
+	f.CreateDBCalled = true
+	f.CreateDBDBName = dbname
+
+	return f.CreateDBError
+}
+
+func (f *FakeSQLEngine) DropDB(dbname string) error {
+	f.DropDBCalled = true
+	f.DropDBDBName = dbname
+
+	return f.DropDBError
+}
+
+func (f *FakeSQLEngine) CreateUser(username string, password string) error {
+	f.CreateUserCalled = true
+	f.CreateUserUsername = username
+	f.CreateUserPassword = password
+
+	return f.CreateUserError
+}
+
+func (f *FakeSQLEngine) DropUser(username string) error {
+	f.DropUserCalled = true
+	f.DropUserUsername = username
+
+	return f.DropUserError
+}
+
+func (f *FakeSQLEngine) Privileges() (map[string][]string, error) {
+	f.PrivilegesCalled = true
+
+	return f.PrivilegesPrivileges, f.PrivilegesError
+}
+
+func (f *FakeSQLEngine) GrantPrivileges(dbname string, username string) error {
+	f.GrantPrivilegesCalled = true
+	f.GrantPrivilegesDBName = dbname
+	f.GrantPrivilegesUsername = username
+
+	return f.GrantPrivilegesError
+}
+
+func (f *FakeSQLEngine) RevokePrivileges(dbname string, username string) error {
+	f.RevokePrivilegesCalled = true
+	f.RevokePrivilegesDBName = dbname
+	f.RevokePrivilegesUsername = username
+
+	return f.RevokePrivilegesError
+}
+
+func (f *FakeSQLEngine) URI(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("fake://%s:%s@%s:%d/%s?reconnect=true", username, password, address, port, dbname)
+}
+
+func (f *FakeSQLEngine) JDBCURI(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("jdbc:fake://%s:%d/%s?user=%s&password=%s", address, port, dbname, username, password)
+}

--- a/sqlengine/mysql_engine.go
+++ b/sqlengine/mysql_engine.go
@@ -1,0 +1,185 @@
+package sqlengine
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/go-sql-driver/mysql" // MySQL Driver
+
+	"github.com/pivotal-golang/lager"
+)
+
+type MySQLEngine struct {
+	logger lager.Logger
+	db     *sql.DB
+}
+
+func NewMySQLEngine(logger lager.Logger) *MySQLEngine {
+	return &MySQLEngine{
+		logger: logger.Session("mysql-engine"),
+	}
+}
+
+func (d *MySQLEngine) Open(address string, port int64, dbname string, username string, password string) error {
+	connectionString := d.connectionString(address, port, dbname, username, password)
+	d.logger.Debug("sql-open", lager.Data{"connection-string": connectionString})
+
+	db, err := sql.Open("mysql", connectionString)
+	if err != nil {
+		return err
+	}
+
+	d.db = db
+
+	return nil
+}
+
+func (d *MySQLEngine) Close() {
+	if d.db != nil {
+		d.db.Close()
+	}
+}
+
+func (d *MySQLEngine) ExistsDB(dbname string) (bool, error) {
+	selectDatabaseStatement := "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '" + dbname + "'"
+	d.logger.Debug("database-exists", lager.Data{"statement": selectDatabaseStatement})
+
+	var dummy string
+	err := d.db.QueryRow(selectDatabaseStatement).Scan(&dummy)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (d *MySQLEngine) CreateDB(dbname string) error {
+	ok, err := d.ExistsDB(dbname)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+
+	createDBStatement := "CREATE DATABASE IF NOT EXISTS " + dbname
+	d.logger.Debug("create-database", lager.Data{"statement": createDBStatement})
+
+	if _, err := d.db.Exec(createDBStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *MySQLEngine) DropDB(dbname string) error {
+	dropDBStatement := "DROP DATABASE IF EXISTS " + dbname
+	d.logger.Debug("drop-database", lager.Data{"statement": dropDBStatement})
+
+	if _, err := d.db.Exec(dropDBStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *MySQLEngine) CreateUser(username string, password string) error {
+	createUserStatement := "CREATE USER '" + username + "' IDENTIFIED BY '" + password + "'"
+	d.logger.Debug("create-user", lager.Data{"statement": createUserStatement})
+
+	if _, err := d.db.Exec(createUserStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *MySQLEngine) DropUser(username string) error {
+	dropUserStatement := "DROP USER '" + username + "'@'%'"
+	d.logger.Debug("drop-user", lager.Data{"statement": dropUserStatement})
+
+	if _, err := d.db.Exec(dropUserStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *MySQLEngine) Privileges() (map[string][]string, error) {
+	privileges := make(map[string][]string)
+
+	selectPrivilegesStatement := "SELECT db, user FROM mysql.db"
+	d.logger.Debug("database-privileges", lager.Data{"statement": selectPrivilegesStatement})
+
+	rows, err := d.db.Query(selectPrivilegesStatement)
+	if err != nil {
+		d.logger.Error("sql-error", err)
+		return privileges, err
+	}
+	defer rows.Close()
+
+	var dbname, username string
+	for rows.Next() {
+		err := rows.Scan(&dbname, &username)
+		if err != nil {
+			d.logger.Error("sql-error", err)
+			return privileges, err
+		}
+		if _, ok := privileges[dbname]; !ok {
+			privileges[dbname] = []string{}
+		}
+		privileges[dbname] = append(privileges[dbname], username)
+	}
+	err = rows.Err()
+	if err != nil {
+		d.logger.Error("sql-error", err)
+		return privileges, err
+	}
+
+	d.logger.Debug("database-privileges", lager.Data{"output": privileges})
+
+	return privileges, nil
+}
+
+func (d *MySQLEngine) GrantPrivileges(dbname string, username string) error {
+	grantPrivilegesStatement := "GRANT ALL PRIVILEGES ON " + dbname + ".* TO '" + username + "'@'%'"
+	d.logger.Debug("grant-privileges", lager.Data{"statement": grantPrivilegesStatement})
+
+	if _, err := d.db.Exec(grantPrivilegesStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *MySQLEngine) RevokePrivileges(dbname string, username string) error {
+	revokePrivilegesStatement := "REVOKE ALL PRIVILEGES ON " + dbname + ".* from '" + username + "'@'%'"
+	d.logger.Debug("revoke-privileges", lager.Data{"statement": revokePrivilegesStatement})
+
+	if _, err := d.db.Exec(revokePrivilegesStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *MySQLEngine) URI(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("mysql://%s:%s@%s:%d/%s?reconnect=true", username, password, address, port, dbname)
+}
+
+func (d *MySQLEngine) JDBCURI(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("jdbc:mysql://%s:%d/%s?user=%s&password=%s", address, port, dbname, username, password)
+}
+
+func (d *MySQLEngine) connectionString(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", username, password, address, port, dbname)
+}

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -1,0 +1,195 @@
+package sqlengine
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq" // PostgreSQL Driver
+
+	"github.com/pivotal-golang/lager"
+)
+
+type PostgresEngine struct {
+	logger lager.Logger
+	db     *sql.DB
+}
+
+func NewPostgresEngine(logger lager.Logger) *PostgresEngine {
+	return &PostgresEngine{
+		logger: logger.Session("postgres-engine"),
+	}
+}
+
+func (d *PostgresEngine) Open(address string, port int64, dbname string, username string, password string) error {
+	connectionString := d.connectionString(address, port, dbname, username, password)
+	d.logger.Debug("sql-open", lager.Data{"connection-string": connectionString})
+
+	db, err := sql.Open("postgres", connectionString)
+	if err != nil {
+		return err
+	}
+
+	d.db = db
+
+	return nil
+}
+
+func (d *PostgresEngine) Close() {
+	if d.db != nil {
+		d.db.Close()
+	}
+}
+
+func (d *PostgresEngine) ExistsDB(dbname string) (bool, error) {
+	selectDatabaseStatement := "SELECT datname FROM pg_database WHERE datname='" + dbname + "'"
+	d.logger.Debug("database-exists", lager.Data{"statement": selectDatabaseStatement})
+
+	var dummy string
+	err := d.db.QueryRow(selectDatabaseStatement).Scan(&dummy)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (d *PostgresEngine) CreateDB(dbname string) error {
+	ok, err := d.ExistsDB(dbname)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+
+	createDBStatement := "CREATE DATABASE \"" + dbname + "\""
+	d.logger.Debug("create-database", lager.Data{"statement": createDBStatement})
+
+	if _, err := d.db.Exec(createDBStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *PostgresEngine) DropDB(dbname string) error {
+	if err := d.dropConnections(dbname); err != nil {
+		return err
+	}
+
+	dropDBStatement := "DROP DATABASE IF EXISTS \"" + dbname + "\""
+	d.logger.Debug("drop-database", lager.Data{"statement": dropDBStatement})
+
+	if _, err := d.db.Exec(dropDBStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *PostgresEngine) CreateUser(username string, password string) error {
+	createUserStatement := "CREATE USER \"" + username + "\" WITH PASSWORD '" + password + "'"
+	d.logger.Debug("create-user", lager.Data{"statement": createUserStatement})
+
+	if _, err := d.db.Exec(createUserStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *PostgresEngine) DropUser(username string) error {
+	// For PostgreSQL we don't drop the user because it might still be owner of some objects
+
+	return nil
+}
+
+func (d *PostgresEngine) Privileges() (map[string][]string, error) {
+	privileges := make(map[string][]string)
+
+	selectPrivilegesStatement := "SELECT datname, usename FROM pg_database d, pg_user u WHERE usecreatedb = false AND (SELECT has_database_privilege(u.usename, d.datname, 'create'))"
+	d.logger.Debug("database-privileges", lager.Data{"statement": selectPrivilegesStatement})
+
+	rows, err := d.db.Query(selectPrivilegesStatement)
+	if err != nil {
+		d.logger.Error("sql-error", err)
+		return privileges, err
+	}
+	defer rows.Close()
+
+	var dbname, username string
+	for rows.Next() {
+		err := rows.Scan(&dbname, &username)
+		if err != nil {
+			d.logger.Error("sql-error", err)
+			return privileges, err
+		}
+		if _, ok := privileges[dbname]; !ok {
+			privileges[dbname] = []string{}
+		}
+		privileges[dbname] = append(privileges[dbname], username)
+	}
+	err = rows.Err()
+	if err != nil {
+		d.logger.Error("sql-error", err)
+		return privileges, err
+	}
+
+	d.logger.Debug("database-privileges", lager.Data{"output": privileges})
+
+	return privileges, nil
+}
+
+func (d *PostgresEngine) GrantPrivileges(dbname string, username string) error {
+	grantPrivilegesStatement := "GRANT ALL PRIVILEGES ON DATABASE \"" + dbname + "\" TO \"" + username + "\""
+	d.logger.Debug("grant-privileges", lager.Data{"statement": grantPrivilegesStatement})
+
+	if _, err := d.db.Exec(grantPrivilegesStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *PostgresEngine) RevokePrivileges(dbname string, username string) error {
+	revokePrivilegesStatement := "REVOKE ALL PRIVILEGES ON DATABASE \"" + dbname + "\" FROM \"" + username + "\""
+	d.logger.Debug("revoke-privileges", lager.Data{"statement": revokePrivilegesStatement})
+
+	if _, err := d.db.Exec(revokePrivilegesStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *PostgresEngine) URI(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?reconnect=true", username, password, address, port, dbname)
+}
+
+func (d *PostgresEngine) JDBCURI(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?user=%s&password=%s", address, port, dbname, username, password)
+}
+
+func (d *PostgresEngine) dropConnections(dbname string) error {
+	dropDBConnectionsStatement := "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + dbname + "' AND pid <> pg_backend_pid()"
+	d.logger.Debug("drop-connections", lager.Data{"statement": dropDBConnectionsStatement})
+
+	if _, err := d.db.Exec(dropDBConnectionsStatement); err != nil {
+		d.logger.Error("sql-error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (d *PostgresEngine) connectionString(address string, port int64, dbname string, username string, password string) string {
+	return fmt.Sprintf("host=%s port=%d dbname=%s user='%s' password='%s'", address, port, dbname, username, password)
+}

--- a/sqlengine/provider.go
+++ b/sqlengine/provider.go
@@ -1,0 +1,5 @@
+package sqlengine
+
+type Provider interface {
+	GetSQLEngine(engine string) (SQLEngine, error)
+}

--- a/sqlengine/provider_service.go
+++ b/sqlengine/provider_service.go
@@ -1,0 +1,27 @@
+package sqlengine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pivotal-golang/lager"
+)
+
+type ProviderService struct {
+	logger lager.Logger
+}
+
+func NewProviderService(logger lager.Logger) *ProviderService {
+	return &ProviderService{logger: logger}
+}
+
+func (p *ProviderService) GetSQLEngine(engine string) (SQLEngine, error) {
+	switch strings.ToLower(engine) {
+	case "aurora", "mariadb", "mysql":
+		return NewMySQLEngine(p.logger), nil
+	case "postgres", "postgresql":
+		return NewPostgresEngine(p.logger), nil
+	}
+
+	return nil, fmt.Errorf("SQL Engine '%s' not supported", engine)
+}

--- a/sqlengine/provider_service_test.go
+++ b/sqlengine/provider_service_test.go
@@ -1,0 +1,70 @@
+package sqlengine_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/sqlengine"
+
+	"github.com/pivotal-golang/lager"
+)
+
+var _ = Describe("Provider Service", func() {
+	var (
+		sqlProvider *ProviderService
+		logger      lager.Logger
+	)
+
+	BeforeEach(func() {
+		logger = lager.NewLogger("provider_service_test")
+		sqlProvider = NewProviderService(logger)
+	})
+
+	Describe("GetSQLEngine", func() {
+		It("returns error if engine is not supported", func() {
+			_, err := sqlProvider.GetSQLEngine("unknown")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("SQL Engine 'unknown' not supported"))
+		})
+
+		Context("when engine is aurora", func() {
+			It("return the proper SQL Engine", func() {
+				sqlEngine, err := sqlProvider.GetSQLEngine("aurora")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sqlEngine).To(BeAssignableToTypeOf(&MySQLEngine{}))
+			})
+		})
+
+		Context("when engine is mariadb", func() {
+			It("return the proper SQL Engine", func() {
+				sqlEngine, err := sqlProvider.GetSQLEngine("mariadb")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sqlEngine).To(BeAssignableToTypeOf(&MySQLEngine{}))
+			})
+		})
+
+		Context("when engine is mysql", func() {
+			It("return the proper SQL Engine", func() {
+				sqlEngine, err := sqlProvider.GetSQLEngine("mysql")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sqlEngine).To(BeAssignableToTypeOf(&MySQLEngine{}))
+			})
+		})
+
+		Context("when engine is postgres", func() {
+			It("return the proper SQL Engine", func() {
+				sqlEngine, err := sqlProvider.GetSQLEngine("postgres")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sqlEngine).To(BeAssignableToTypeOf(&PostgresEngine{}))
+			})
+		})
+
+		Context("when engine is postgresql", func() {
+			It("return the proper SQL Engine", func() {
+				sqlEngine, err := sqlProvider.GetSQLEngine("postgresql")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sqlEngine).To(BeAssignableToTypeOf(&PostgresEngine{}))
+			})
+		})
+	})
+})

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -1,0 +1,16 @@
+package sqlengine
+
+type SQLEngine interface {
+	Open(address string, port int64, dbname string, username string, password string) error
+	Close()
+	ExistsDB(dbname string) (bool, error)
+	CreateDB(dbname string) error
+	DropDB(dbname string) error
+	CreateUser(username string, password string) error
+	DropUser(username string) error
+	Privileges() (map[string][]string, error)
+	GrantPrivileges(dbname string, username string) error
+	RevokePrivileges(dbname string, username string) error
+	URI(address string, port int64, dbname string, username string, password string) string
+	JDBCURI(address string, port int64, dbname string, username string, password string) string
+}

--- a/sqlengine/sql_engine_suite_test.go
+++ b/sqlengine/sql_engine_suite_test.go
@@ -1,0 +1,13 @@
+package sqlengine_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSQLEngine(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SQL Engine Suite")
+}

--- a/sqsbroker/broker.go
+++ b/sqsbroker/broker.go
@@ -45,6 +45,17 @@ func New(
 	}
 }
 
+func (b *SQSBroker) ServicesAsString() string {
+	catalog, err := json.Marshal(b.catalog.Services)
+
+	if err != nil {
+		b.logger.Error("marshal-error", err)
+		return ""
+	}
+
+	return string(catalog)
+}
+
 func (b *SQSBroker) Services() brokerapi.CatalogResponse {
 	catalogResponse := brokerapi.CatalogResponse{}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"math"
+)
+
+var alpha = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+var numer = []byte("0123456789")
+
+func RandomAlphaNum(length int) string {
+	return randChar(1, alpha) + randChar(length-1, append(alpha, numer...))
+}
+
+func randChar(length int, chars []byte) string {
+	newPword := make([]byte, length)
+	randomData := make([]byte, length+(length/4))
+	clen := byte(len(chars))
+	maxrb := byte(256 - (256 % len(chars)))
+	i := 0
+	for {
+		if _, err := io.ReadFull(rand.Reader, randomData); err != nil {
+			panic(err)
+		}
+		for _, c := range randomData {
+			if c >= maxrb {
+				continue
+			}
+			newPword[i] = chars[c%clen]
+			i++
+			if i == length {
+				return string(newPword)
+			}
+		}
+	}
+}
+
+func GetMD5B64(text string, length int) string {
+	hasher := md5.New()
+	md5 := hasher.Sum([]byte(text))
+	return base64.StdEncoding.EncodeToString(md5)[0:int(math.Min(float64(length), float64(len(md5))))]
+}

--- a/utils/utils_suite_test.go
+++ b/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,22 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cf-platform-eng/sqs-broker/utils"
+)
+
+var _ = Describe("RandomAlphaNum", func() {
+	It("generates a random alpha numeric with the proper length", func() {
+		randomString := RandomAlphaNum(32)
+		Expect(len(randomString)).To(Equal(32))
+	})
+})
+
+var _ = Describe("GetMD5B64", func() {
+	It("returns the Base64 of a string MD5", func() {
+		md5b64 := GetMD5B64("ce71b484-d542-40f7-9dd4-5526e38c81ba", 32)
+		Expect(md5b64).To(Equal("Y2U3MWI0ODQtZDU0Mi00MGY3LTlkZDQt"))
+	})
+})


### PR DESCRIPTION
Hey @jcscottiii, @mogul, @dlapiduz!

So this is a continuation of what we were discussing over in https://github.com/18F/aws-broker/pull/5.

I was mentally hitting some walls trying to augment the existing AWS Broker. The [original version from which it was forked](https://github.com/cloudfoundry-community/rds-broker) was built on a pattern that came before the [V2 pattern](https://github.com/pivotal-cf/brokerapi) on which the SQS Broker is built. So as I was trying to augment it with the [SQS Broker](https://github.com/cf-platform-eng/sqs-broker), I was breaking things left and right while trying to map the two together.

So, this morning, I thought, "what if we started with a V2 Broker api project as the base for the monolithic AWS Broker?" That's what this PR is tracking. I first grabbed the SQS Broker as the base and rolled the RDS Broker into it. It gets a bit clunky in the imports--I basically injected the meat of the RDS Broker into the SQS Broker, so you have paths like /sqs-broker/rds-broker, but it works.

Currently I just have parity with my other AWS Broker attempt--i.e., showing a combined catalog. The way in which that is implement here is better, IMO, though it stands to be made less brittle. I augmented each of the brokers to have a simple method to return a stringified version of their services. I then stitch that together and provide that as a JSON response. This could scale to N brokers, but it will require manually massaging that JSON string stitcher. Future optimization would definitely be needed.

The beauty of this approach is both brokers are built on a standard pattern, making reasoning about them much easier. The next step is to implement a simple router that will call the appropriate method given the serviceID (that should "just work"...).

I would love to hear your thoughts on this! I don't have a graceful path for merging into the AWS Broker repo--the idea being this would be a major version bump for that project that potentially breaks backwards compatibility. This also makes pulling in changes to either base repo more difficult, but that will be the case with any monolithic broker.
